### PR TITLE
fix: add missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/tgriesser"
   },
   "dependencies": {
+    "prettier": "^1.14.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -42,7 +43,6 @@
     "husky": "^1.1.2",
     "jest": "^23.6.0",
     "lint-staged": "^7.3.0",
-    "prettier": "^1.14.3",
     "ts-jest": "^23.10.4",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",


### PR DESCRIPTION
prettierFormat requires prettier to be present to format metadata output

Currently I get this error when using nexus. 
```
ERROR in ./node_modules/nexus/dist/prettierFormat.js
Module not found: Error: Can't resolve 'prettier' in 'PATH/node_modules/nexus/dist'
 @ ./node_modules/nexus/dist/prettierFormat.js 13:35-54
 @ ./node_modules/nexus/dist/metadata.js
 @ ./node_modules/nexus/dist/core.js
 @ ./node_modules/nexus/dist/index.js
 @ ./src/graphql/schema.ts
 @ ./src/graphql.ts
```

either we had prettier as a dependency or we ask developers to install it and add prettier to the `peerDependencies` section. 