### PR TITLE
Inline resolver, full-type safety on fields

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,15 +104,15 @@ const AccountInfo = objectType("AccountInfo", (t) => {
 });
 ```
 
-## Resolving: Property
+## Resolving: Inline Function
 
-One common idiom in GraphQL is exposing fields that mask or rename the property name on the backing object. GraphQL Nexus provides a `property` option on the field configuration object, for conveniently accessing an object property without needing to define a resolver function.
+One common idiom in GraphQL is exposing fields that mask or rename the property name on the backing object. GraphQL Nexus makes this simple by allowing a function as the second parameter to the resolver function.
 
 ```ts
 const User = objectType("User", (t) => {
-  t.id("id", { property: "user_id" });
-  t.id("name", { property: "user_name" });
-  t.id("description", { property: "user_description" });
+  t.id("id", (o) => o.user_id);
+  t.id("name", (o) => o.user_name);
+  t.id("description", (o) => o.user_description);
 });
 ```
 

--- a/docs/type-generation.md
+++ b/docs/type-generation.md
@@ -14,8 +14,7 @@ GraphQL Nexus was designed with TypeScript in mind. In order to fully typecheck 
 
 A **backing type** is a type representation of the value used to resolve the fields of an object type. In GraphQL terminology this is the `rootValue` for the object. Other tools like Prisma refer to this as a `model`.
 
-Whatever you want to call it, just think of it as the object that will be passed as the first argument of `resolve`. It can be a plain JS object, a database model, a mongoose document, a JS class, anything that fulfills the contract defined by the GraphQL object type, based on
-the field definitions.
+Whatever you want to call it, just think of it as the object that will be passed as the first argument of `resolve`. It can be a plain JS object, a database model, a mongoose document, a JS class, anything that fulfills the contract defined by the GraphQL object type, based on the field definitions.
 
 Scalars can also have backing types, representing the value they are parsed into.
 

--- a/examples/apollo-fullstack/src/fullstack-typegen.ts
+++ b/examples/apollo-fullstack/src/fullstack-typegen.ts
@@ -39,8 +39,6 @@ export interface QueryLaunchesArgs {
 
 export type QueryMeReturnType = null | User_ReturnType;
 
-export type QueryRootType = {};
-
 export type Query_ReturnType = {};
 
 export type LaunchIdReturnType = string;
@@ -133,8 +131,6 @@ export interface MutationLoginArgs {
   email?: null | string;
 }
 
-export type MutationRootType = {};
-
 export type Mutation_ReturnType = {};
 
 export type TripUpdateResponseLaunchesReturnType = null | Launch_ReturnType;
@@ -171,13 +167,13 @@ export interface GraphQLNexusGenArgTypes {
 }
 
 export interface GraphQLNexusGenRootTypes {
-  Query: QueryRootType;
+  Query: {};
   Launch: LaunchRootType;
   Mission: MissionRootType;
   Rocket: RocketRootType;
   LaunchConnection: LaunchConnectionRootType;
   User: UserRootType;
-  Mutation: MutationRootType;
+  Mutation: {};
   TripUpdateResponse: TripUpdateResponseRootType;
 }
 
@@ -234,13 +230,13 @@ export interface GraphQLNexusGenTypes {
     PatchSize: PatchSize;
   };
   objects: {
-    Query: QueryRootType;
+    Query: {};
     Launch: LaunchRootType;
     Mission: MissionRootType;
     Rocket: RocketRootType;
     LaunchConnection: LaunchConnectionRootType;
     User: UserRootType;
-    Mutation: MutationRootType;
+    Mutation: {};
     TripUpdateResponse: TripUpdateResponseRootType;
   };
   interfaces: {};

--- a/examples/apollo-fullstack/src/schema/query.ts
+++ b/examples/apollo-fullstack/src/schema/query.ts
@@ -1,4 +1,4 @@
-/// <reference path="../fullstackTypes.ts" />
+/// <reference path="../fullstack-typegen.ts" />
 import { objectType, idArg, intArg, stringArg } from "nexus";
 import { Utils } from "../typeDefs";
 const utils: Utils = require("fullstack-tutorial/final/server/src/utils.js");

--- a/examples/githunt-api/githunt-api-schema.graphql
+++ b/examples/githunt-api/githunt-api-schema.graphql
@@ -10,8 +10,6 @@ enum CacheControlScope {
 type Comment {
   """The text of the comment"""
   content: String!
-
-  """A timestamp of when the comment was posted"""
   createdAt: Float!
 
   """The SQL ID of this entry"""

--- a/examples/githunt-api/src/githunt-typegen.ts
+++ b/examples/githunt-api/src/githunt-typegen.ts
@@ -39,11 +39,6 @@ export interface QueryFeedArgs {
   type: FeedType;
 }
 
-export interface QueryRootType {
-  currentUser: any;
-  entry?: null | any;
-}
-
 export type Query_ReturnType = {
   currentUser: MaybeThunk<MaybePromise<any>>;
   entry?: MaybeThunkArgs<MaybePromise<null | any>, QueryEntryArgs>;
@@ -94,7 +89,6 @@ export interface EntryRootType {
   commentCount: number;
   comments: any[];
   createdAt: number;
-  hot_score: number;
   id: number;
   postedBy?: null | any;
   repository: any;
@@ -106,7 +100,6 @@ export type Entry_ReturnType = {
   commentCount: MaybeThunk<MaybePromise<number>>;
   comments: MaybeThunkArgs<MaybePromise<any[]>, EntryCommentsArgs>;
   createdAt: MaybeThunk<MaybePromise<number>>;
-  hot_score: MaybeThunk<MaybePromise<number>>;
   id: MaybeThunk<MaybePromise<number>>;
   postedBy?: MaybeThunk<MaybePromise<null | any>>;
   repository: MaybeThunk<MaybePromise<any>>;
@@ -126,7 +119,6 @@ export type CommentRepoNameReturnType = string;
 
 export interface CommentRootType {
   content: string;
-  created_at: number;
   id: number;
   postedBy?: null | any;
   repoName: string;
@@ -134,7 +126,6 @@ export interface CommentRootType {
 
 export type Comment_ReturnType = {
   content: MaybeThunk<MaybePromise<string>>;
-  created_at: MaybeThunk<MaybePromise<number>>;
   id: MaybeThunk<MaybePromise<number>>;
   postedBy?: MaybeThunk<MaybePromise<null | any>>;
   repoName: MaybeThunk<MaybePromise<string>>;
@@ -206,12 +197,6 @@ export interface MutationVoteArgs {
   type: VoteType;
 }
 
-export interface MutationRootType {
-  submitComment: any;
-  submitRepository: any;
-  vote: any;
-}
-
 export type Mutation_ReturnType = {
   submitComment: MaybeThunkArgs<MaybePromise<any>, MutationSubmitCommentArgs>;
   submitRepository: MaybeThunkArgs<MaybePromise<any>, MutationSubmitRepositoryArgs>;
@@ -238,13 +223,13 @@ export interface GraphQLNexusGenArgTypes {
 }
 
 export interface GraphQLNexusGenRootTypes {
-  Query: QueryRootType;
+  Query: {};
   User: UserRootType;
   Entry: EntryRootType;
   Comment: CommentRootType;
   Repository: RepositoryRootType;
   Vote: VoteRootType;
-  Mutation: MutationRootType;
+  Mutation: {};
 }
 
 export interface GraphQLNexusGenReturnTypes {
@@ -306,13 +291,13 @@ export interface GraphQLNexusGenTypes {
     CacheControlScope: CacheControlScope;
   };
   objects: {
-    Query: QueryRootType;
+    Query: {};
     User: UserRootType;
     Entry: EntryRootType;
     Comment: CommentRootType;
     Repository: RepositoryRootType;
     Vote: VoteRootType;
-    Mutation: MutationRootType;
+    Mutation: {};
   };
   interfaces: {};
   unions: {};

--- a/examples/githunt-api/src/schema.js
+++ b/examples/githunt-api/src/schema.js
@@ -128,8 +128,7 @@ exports.Comment = objectType("Comment", (t) => {
   commonFields(t);
   t.description("A comment about an entry, submitted by a user");
   t.directive("cacheControl", { maxAge: 240 });
-  t.float("createdAt", {
-    property: "created_at",
+  t.float("createdAt", (o) => o.created_at, {
     description: "A timestamp of when the comment was posted",
   });
   t.string("content", {
@@ -159,7 +158,7 @@ exports.Entry = objectType("Entry", (t) => {
     description: "The score of this repository, upvotes - downvotes",
   });
   t.float("hotScore", {
-    property: "hot_score",
+    resolve: (o) => o.hot_score,
     description: "The hot score of this repository",
   });
   t.field("comments", "Comment", {

--- a/examples/kitchen-sink/kitchen-sink-schema.graphql
+++ b/examples/kitchen-sink/kitchen-sink-schema.graphql
@@ -19,5 +19,5 @@ input InputType {
 }
 
 type Query {
-  ok: Boolean!
+  bar: Bar!
 }

--- a/examples/kitchen-sink/src/definitions.ts
+++ b/examples/kitchen-sink/src/definitions.ts
@@ -14,7 +14,7 @@ export const Foo = objectType("Foo", (t) => {
 
 export const InputType = inputObjectType("InputType", (t) => {
   t.string("key", { required: true });
-  t.int("answer", { default: "a" });
+  t.int("answer");
 });
 
 export const Query = objectType("Query", (t) => {

--- a/examples/kitchen-sink/src/definitions.ts
+++ b/examples/kitchen-sink/src/definitions.ts
@@ -1,10 +1,4 @@
-import {
-  objectType,
-  inputObjectType,
-  enumType,
-  scalarType,
-  interfaceType,
-} from "nexus";
+import { objectType, inputObjectType, interfaceType } from "nexus";
 
 export const Bar = interfaceType("Bar", (t) => {
   t.boolean("ok");
@@ -21,4 +15,10 @@ export const Foo = objectType("Foo", (t) => {
 export const InputType = inputObjectType("InputType", (t) => {
   t.string("key", { required: true });
   t.int("answer", { default: "a" });
+});
+
+export const Query = objectType("Query", (t) => {
+  t.field("bar", "Bar", {
+    resolve: () => ({ ok: true }),
+  });
 });

--- a/examples/kitchen-sink/src/kitchen-sink-typegen.ts
+++ b/examples/kitchen-sink/src/kitchen-sink-typegen.ts
@@ -25,9 +25,7 @@ export type MaybeThunkArgs<T, A> = T | ((args?: A) => T);
 
 export type QueryBarReturnType = Bar_ReturnType;
 
-export type Query_ReturnType = {
-  bar: MaybeThunk<MaybePromise<any>>;
-}
+export type Query_ReturnType = {};
 
 export type BarOkReturnType = boolean;
 

--- a/examples/kitchen-sink/src/kitchen-sink-typegen.ts
+++ b/examples/kitchen-sink/src/kitchen-sink-typegen.ts
@@ -23,14 +23,10 @@ export type MaybeThunk<T> = T | (() => T);
 // Maybe Thunk, with args
 export type MaybeThunkArgs<T, A> = T | ((args?: A) => T);
 
-export type QueryOkReturnType = boolean;
-
-export interface QueryRootType {
-  ok: boolean;
-}
+export type QueryBarReturnType = Bar_ReturnType;
 
 export type Query_ReturnType = {
-  ok: MaybeThunk<MaybePromise<boolean>>;
+  bar: MaybeThunk<MaybePromise<any>>;
 }
 
 export type BarOkReturnType = boolean;
@@ -66,13 +62,13 @@ export interface GraphQLNexusGenArgTypes {
 export interface GraphQLNexusGenRootTypes {
   Bar: BarRootType;
   Baz: BazRootType;
-  Query: QueryRootType;
+  Query: {};
   Foo: FooRootType;
 }
 
 export interface GraphQLNexusGenReturnTypes {
   Query: {
-    ok: QueryOkReturnType;
+    bar: QueryBarReturnType;
   };
   Bar: {
     ok: BarOkReturnType;
@@ -92,7 +88,7 @@ export interface GraphQLNexusGenTypes {
   context: unknown;
   enums: {};
   objects: {
-    Query: QueryRootType;
+    Query: {};
     Foo: FooRootType;
   };
   interfaces: {

--- a/examples/kitchen-sink/tsconfig.json
+++ b/examples/kitchen-sink/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "lib": ["es2015"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "allowJs": true,
+    "strictNullChecks": true,
+    "skipLibCheck": true
+  }
+}

--- a/examples/star-wars/src/graphql/character.ts
+++ b/examples/star-wars/src/graphql/character.ts
@@ -14,7 +14,7 @@ export const Character = interfaceType("Character", (t) => {
   t.field("appearsIn", "Episode", {
     list: true,
     description: "Which movies they appear in.",
-    property: "appears_in",
+    resolve: (o) => o.appears_in,
     args: {
       id: idArg({ required: true }),
     },

--- a/examples/star-wars/src/graphql/human.ts
+++ b/examples/star-wars/src/graphql/human.ts
@@ -6,6 +6,6 @@ export const Human = objectType("Human", (t) => {
   t.string("homePlanet", {
     nullable: true,
     description: "The home planet of the human, or null if unknown.",
-    property: "home_planet",
+    resolve: (o) => o.home_planet || null,
   });
 });

--- a/examples/star-wars/src/star-wars-typegen.ts
+++ b/examples/star-wars/src/star-wars-typegen.ts
@@ -41,8 +41,6 @@ export interface QueryHumanArgs {
   id: string;
 }
 
-export type QueryRootType = {};
-
 export type Query_ReturnType = {};
 
 export type DroidAppearsInReturnType = MaybePromiseList<Episode>;
@@ -116,7 +114,7 @@ export interface GraphQLNexusGenArgTypes {
 
 export interface GraphQLNexusGenRootTypes {
   Character: CharacterRootType;
-  Query: QueryRootType;
+  Query: {};
   Droid: DroidRootType;
   Human: HumanRootType;
 }
@@ -159,7 +157,7 @@ export interface GraphQLNexusGenTypes {
     MoreEpisodes: MoreEpisodes;
   };
   objects: {
-    Query: QueryRootType;
+    Query: {};
     Droid: DroidRootType;
     Human: HumanRootType;
   };

--- a/examples/star-wars/src/types/backingTypes.ts
+++ b/examples/star-wars/src/types/backingTypes.ts
@@ -1,3 +1,5 @@
+import { Episode } from "../star-wars-typegen";
+
 /**
  * These are Flow types which correspond to the schema.
  * They represent the shape of the data visited during field resolution.
@@ -6,7 +8,7 @@ export interface CharacterFields {
   id: string;
   name: string;
   friends: string[];
-  appears_in: number[];
+  appears_in: Episode[];
 }
 
 export interface Human extends CharacterFields {

--- a/examples/ts-ast-reader/src/ts-ast-reader-typegen.ts
+++ b/examples/ts-ast-reader/src/ts-ast-reader-typegen.ts
@@ -30,8 +30,6 @@ export interface QueryParseFileArgs {
   file: string;
 }
 
-export type QueryRootType = {};
-
 export type Query_ReturnType = {};
 
 export type SourceFileEndReturnType = number;
@@ -2255,7 +2253,7 @@ export interface GraphQLNexusGenRootTypes {
   HasJSDoc: HasJSDocRootType;
   JSDocTag: JSDocTagRootType;
   MaybeOptional: MaybeOptionalRootType;
-  Query: QueryRootType;
+  Query: {};
   SourceFile: SourceFileRootType;
   Token: TokenRootType;
   BindingPattern: BindingPatternRootType;
@@ -3194,7 +3192,7 @@ export interface GraphQLNexusGenTypes {
     SyntaxKind: SyntaxKind;
   };
   objects: {
-    Query: QueryRootType;
+    Query: {};
     SourceFile: SourceFileRootType;
     Token: TokenRootType;
     BindingPattern: BindingPatternRootType;

--- a/examples/ts-ast-reader/src/types/interfaces.ts
+++ b/examples/ts-ast-reader/src/types/interfaces.ts
@@ -24,7 +24,7 @@ export const Node = interfaceType("Node", (t) => {
   t.field("name", "DeclarationName", { nullable: true });
   t.field("typeName", "DeclarationName", { nullable: true });
   t.field("kind", "SyntaxKind");
-  t.int("kindCode", { property: "kind" });
+  t.int("kindCode", (o) => o.kind);
   t.field("flags", "NodeFlags");
   // t.field('decorators', 'Decorator', {list: true, nullable: true})
   t.field("modifiers", "Token", {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nexus",
   "version": "0.6.2",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist",
+  "types": "src",
   "license": "MIT",
   "description": "Scalable, strongly typed GraphQL schema development",
   "scripts": {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -46,7 +46,7 @@ import {
   WrappedType,
 } from "./core";
 import * as Types from "./types";
-import { propertyFieldResolver, suggestionList, objValues } from "./utils";
+import { suggestionList, objValues } from "./utils";
 import { isObject } from "util";
 
 const isPromise = (val: any): val is Promise<any> =>
@@ -631,14 +631,7 @@ export class SchemaBuilder {
   ) {
     let resolver = typeConfig.defaultResolver || defaultFieldResolver;
     if (fieldOptions.resolve) {
-      if (typeof fieldOptions.property !== "undefined") {
-        console.warn(
-          `Both resolve and property should not be supplied, property will be ignored`
-        );
-      }
       resolver = fieldOptions.resolve;
-    } else if (fieldOptions.property) {
-      resolver = propertyFieldResolver(fieldOptions.property);
     }
     if (typeof fieldOptions.default !== "undefined") {
       resolver = withDefaultValue(resolver, fieldOptions.default);

--- a/src/core.ts
+++ b/src/core.ts
@@ -69,9 +69,9 @@ export class ObjectTypeDef<
    */
   id<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "ID", options);
+    this.field(name, "ID", ...opts);
   }
 
   /**
@@ -79,9 +79,9 @@ export class ObjectTypeDef<
    */
   int<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "Int", options);
+    this.field(name, "Int", ...opts);
   }
 
   /**
@@ -89,9 +89,9 @@ export class ObjectTypeDef<
    */
   float<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "Float", options);
+    this.field(name, "Float", ...opts);
   }
 
   /**
@@ -99,9 +99,9 @@ export class ObjectTypeDef<
    */
   string<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "String", options);
+    this.field(name, "String", ...opts);
   }
 
   /**
@@ -109,9 +109,9 @@ export class ObjectTypeDef<
    */
   boolean<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "Boolean", options);
+    this.field(name, "Boolean", ...opts);
   }
 
   /**
@@ -120,8 +120,14 @@ export class ObjectTypeDef<
   field<FieldName extends string>(
     name: FieldName,
     type: Types.AllOutputTypes<GenTypes> | Types.BaseScalars,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
+    let options: Types.OutputFieldOpts<GenTypes, TypeName, any> = {};
+    if (typeof opts[0] === "function") {
+      options.resolve = opts[0];
+    } else {
+      options = { ...opts[0] };
+    }
     this.typeConfig.fields.push({
       item: Types.NodeType.FIELD,
       config: {
@@ -157,8 +163,8 @@ export class ObjectTypeDef<
   }
 
   /**
-   * Used to modify a field already defined on an interface or
-   * abstract type.
+   * Used to modify a field already defined on an interface or mixed-in
+   * from another type.
    *
    * At this point the type will not change, but the resolver,
    * default, property, or description fields can.
@@ -417,9 +423,9 @@ export class InterfaceTypeDef<
    */
   id<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "ID", options);
+    this.field(name, "ID", ...opts);
   }
 
   /**
@@ -427,9 +433,9 @@ export class InterfaceTypeDef<
    */
   int<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "Int", options);
+    this.field(name, "Int", ...opts);
   }
 
   /**
@@ -437,9 +443,9 @@ export class InterfaceTypeDef<
    */
   float<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "Float", options);
+    this.field(name, "Float", ...opts);
   }
 
   /**
@@ -447,9 +453,9 @@ export class InterfaceTypeDef<
    */
   string<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "String", options);
+    this.field(name, "String", ...opts);
   }
 
   /**
@@ -457,9 +463,9 @@ export class InterfaceTypeDef<
    */
   boolean<FieldName extends string>(
     name: FieldName,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
-    this.field(name, "Boolean", options);
+    this.field(name, "Boolean", ...opts);
   }
 
   /**
@@ -468,8 +474,14 @@ export class InterfaceTypeDef<
   field<FieldName extends string>(
     name: FieldName,
     type: Types.AllOutputTypes<GenTypes> | Types.BaseScalars,
-    options?: Types.OutputFieldOpts<GenTypes, TypeName, FieldName>
+    ...opts: Types.ConditionalOutputFieldOpts<GenTypes, TypeName, FieldName>
   ) {
+    let options: Types.OutputFieldOpts<GenTypes, TypeName, any> = {};
+    if (typeof opts[0] === "function") {
+      options.resolve = opts[0];
+    } else {
+      options = { ...opts[0] };
+    }
     this.typeConfig.fields.push({
       item: Types.NodeType.FIELD,
       config: {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -124,17 +124,6 @@ export class Metadata {
     );
   }
 
-  hasPropertyResolver(type: GraphQLObjectType, fieldName: string) {
-    if (this.isInterfaceField(type, fieldName)) {
-      //
-    }
-    return Boolean(
-      this.objectFieldMeta[type.name] &&
-        this.objectFieldMeta[type.name][fieldName] &&
-        this.objectFieldMeta[type.name][fieldName].property
-    );
-  }
-
   hasDefaultValue(type: GraphQLObjectType, fieldName: string) {
     return Boolean(
       this.objectFieldMeta[type.name] &&
@@ -153,15 +142,6 @@ export class Metadata {
   isInterfaceField(type: GraphQLObjectType, fieldName: string) {
     return Boolean(
       type.getInterfaces().forEach((i) => i.getFields()[fieldName])
-    );
-  }
-
-  // Type Genreation Helpers:
-
-  getPropertyResolver(type: GraphQLObjectType, fieldName: string) {
-    return (
-      this.objectFieldMeta[type.name] &&
-      this.objectFieldMeta[type.name][fieldName].property
     );
   }
 

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -116,7 +116,12 @@ export async function buildTypeDefinitions(
     }
     return suffixed(type.name, "ReturnType");
   };
-  const typeRootTypeName = (typeName: string) => suffixed(typeName, "RootType");
+  const typeRootTypeName = (typeName: string) => {
+    if (isEntryType(typeName)) {
+      return "{}";
+    }
+    return suffixed(typeName, "RootType");
+  };
   const fieldResolverName = (typeName: string, fieldName: string) =>
     suffixed(typeName, fieldName, "Resolver");
 
@@ -238,13 +243,13 @@ export async function buildTypeDefinitions(
       : isNonNullType(field.type)
       ? ":"
       : "?:";
-    if (metadata.hasPropertyResolver(type, field.name)) {
-      return `${metadata.getPropertyResolver(type, field.name)}${colon}`;
-    }
     return `${field.name}${colon}`;
   };
 
   const makeRootType = (type: GraphQLObjectType) => {
+    if (isEntryType(type.name)) {
+      return;
+    }
     if (backingTypeMap[type.name]) {
       allTypeStrings.push(
         `export type ${typeRootTypeName(type.name)} = ${
@@ -529,6 +534,14 @@ export interface GraphQLNexusGenTypes {
 
 export type Gen = GraphQLNexusGenTypes;
 `;
+}
+
+function isEntryType(typeName: string) {
+  return (
+    typeName === "Query" ||
+    typeName === "Mutation" ||
+    typeName === "Subscription"
+  );
 }
 
 const stringify = (v: any) => JSON.stringify(v);

--- a/src/types.ts
+++ b/src/types.ts
@@ -815,36 +815,35 @@ export type ConditionalOutputFieldOpts<
    * 1. If the field actually exists in the "root value"
    */
   FieldName extends keyof RootValue<GenTypes, TypeName>
-    ? /**
-       * 2. And the value of the root field is the expected type
-       */
-      RootValueField<GenTypes, TypeName, FieldName> extends ResultValue<
+  /**
+   * 2. And the value of the root field is the expected type
+   */
+    ? RootValueField<GenTypes, TypeName, FieldName> extends ResultValue<
         GenTypes,
         TypeName,
         FieldName
       >
-      /**
-       * Then the resolver is optional
-       */
-      ?
-          | []
+      ? /**
+         * Then the resolver is optional
+         */
+        | []
           | [OptionalResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
           | [OutputFieldResolver<GenTypes, TypeName, FieldName>]
-        /**
+      : /**
          * Otherwise, if it's the wrong type, then we need a resolver / default for this field
          */
-      :
-          | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
+        | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
           | [OutputFieldResolver<GenTypes, TypeName, FieldName>]
-      /**
+    : /**
        * The field doesn't even exist in the root type, we need a resolver
        */
-    :
-        | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
+      | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
         | [OutputFieldResolver<GenTypes, TypeName, FieldName>];
 
 /**
- * The "Needs Resolver" output field opts means that the
+ * The "Needs Resolver" output field opts means that the resolver cannot
+ * be fulfilled by the "backing value" alone, and therefore needs either
+ * a valid resolver or a "root value".
  */
 export type NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName> =
   | (CommonOutputOpts & {
@@ -857,7 +856,8 @@ export type NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName> =
     });
 
 /**
- * If we already have the correct value for the field, then we
+ * If we already have the correct value for the field from the root type,
+ * then we can provide a resolver or a default value, but we don't have to.
  */
 export type OptionalResolverOutputFieldOpts<
   GenTypes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -637,15 +637,15 @@ export interface TypegenAutoConfigOptions {
   backingTypeMap?: Record<string, string>;
 }
 
-/**
- * Generated type helpers:
- */
-
 export type TypeResolver<GenTypes, TypeName> = (
   root: RootValue<GenTypes, TypeName>,
   context: ContextValue<GenTypes>,
   info: GraphQLResolveInfo
 ) => MaybePromise<Maybe<InterfaceMembers<GenTypes, TypeName>>>;
+
+/**
+ * Generated type helpers:
+ */
 
 type GenTypesShapeKeys =
   | "context"
@@ -810,35 +810,24 @@ export type ConditionalOutputFieldOpts<
   GenTypes = any,
   TypeName = any,
   FieldName = any
-> =
-  /**
-   * 1. If the field actually exists in the "root value"
-   */
-  FieldName extends keyof RootValue<GenTypes, TypeName>
-  /**
-   * 2. And the value of the root field is the expected type
-   */
-    ? RootValueField<GenTypes, TypeName, FieldName> extends ResultValue<
-        GenTypes,
-        TypeName,
-        FieldName
-      >
-      ? /**
-         * Then the resolver is optional
-         */
-        | []
-          | [OptionalResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
-          | [OutputFieldResolver<GenTypes, TypeName, FieldName>]
-      : /**
-         * Otherwise, if it's the wrong type, then we need a resolver / default for this field
-         */
-        | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
-          | [OutputFieldResolver<GenTypes, TypeName, FieldName>]
-    : /**
-       * The field doesn't even exist in the root type, we need a resolver
-       */
-      | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
-        | [OutputFieldResolver<GenTypes, TypeName, FieldName>];
+> = FieldName extends keyof RootValue<GenTypes, TypeName> // If the field actually exists in the "root value"
+  ? RootValueField<GenTypes, TypeName, FieldName> extends ResultValue<
+      GenTypes,
+      TypeName,
+      FieldName
+    > // And the value of the root field is the expected type
+    ? OptionalFieldResolver<GenTypes, TypeName, FieldName> // Then the resolver is optional
+    : NeedsFieldResolver<GenTypes, TypeName, FieldName> // Otherwise, if it's the wrong type, then we need a resolver / default for this field
+  : NeedsFieldResolver<GenTypes, TypeName, FieldName>; // The field doesn't even exist in the root type, we need a resolver
+
+export type OptionalFieldResolver<GenTypes, TypeName, FieldName> =
+  | []
+  | [OptionalResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
+  | [OutputFieldResolver<GenTypes, TypeName, FieldName>];
+
+export type NeedsFieldResolver<GenTypes, TypeName, FieldName> =
+  | [NeedsResolverOutputFieldOpts<GenTypes, TypeName, FieldName>]
+  | [OutputFieldResolver<GenTypes, TypeName, FieldName>];
 
 /**
  * The "Needs Resolver" output field opts means that the resolver cannot

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,4 @@
-import {
-  GraphQLFieldResolver,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
-  isUnionType,
-} from "graphql";
+import { GraphQLObjectType, GraphQLInterfaceType } from "graphql";
 import path from "path";
 import * as Types from "./types";
 
@@ -42,28 +36,6 @@ export const hasField = (
   fieldName: string
 ) => {
   return Boolean(type.getFields()[fieldName]);
-};
-
-/**
- * If a resolve function is not given, then a default resolve behavior is used
- * which takes the property of the source object of the same name as the field
- * and returns it as the result, or if it's a function, returns the result
- * of calling that function while passing along args and context value.
- */
-export const propertyFieldResolver = (
-  key: string
-): GraphQLFieldResolver<any, any> => {
-  return function(source, args, contextValue, info) {
-    // ensure source is a value for which property access is acceptable.
-    if (typeof source === "object" || typeof source === "function") {
-      // TODO: Maybe warn here if key doesn't exist on source?
-      const property = source[key];
-      if (typeof property === "function") {
-        return source[key](args, contextValue, info);
-      }
-      return property;
-    }
-  };
 };
 
 // ----------------------------

--- a/website/pages/playground.html
+++ b/website/pages/playground.html
@@ -50,7 +50,6 @@
                 <li>
                   <a
                     href="https://github.com/graphql-nexus/nexus/tree/develop/examples"
-                    target="_blank"
                     >Examples</a
                   >
                 </li>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -15,7 +15,6 @@ const siteConfig = {
     "Simple, scalable, strongly typed GraphQL schema construction for TypeScript/JavaScript",
   url: "https://graphql-nexus.com", // Your website URL
   baseUrl: "/", // Base URL for your project */
-  noIndex: true,
 
   gaTrackingId: "UA-39763513-4",
 


### PR DESCRIPTION
Adds support for inline resolver signature. Removes `property` option, use inline resolver instead:

```ts
t.int('id', o => o.id_field)

// alias for:

t.int('id', { resolve: o => o.id_field })
```

Enforces type-safety around resolver or default is implemented when not backed by model value fulfilling the correct signature of the field (complete type-safety).

cc @schickling 
