### PR TITLE
fix: wrap authorization on field subscribe

### DIFF
--- a/src/plugins/fieldAuthorizePlugin.ts
+++ b/src/plugins/fieldAuthorizePlugin.ts
@@ -1,4 +1,4 @@
-import { plugin } from "../plugin";
+import { plugin, CreateFieldResolverInfo, MiddlewareFn } from "../plugin";
 import {
   RootValue,
   ArgsValue,
@@ -77,12 +77,85 @@ export const fieldAuthorizePlugin = (
     );
     throw new Error("Not authorized");
   };
+
   let hasWarned = false;
+
+  const authorizationMiddleware = (
+    config: CreateFieldResolverInfo<any, any>
+  ): MiddlewareFn | undefined => {
+    const authorize = config.fieldConfig.extensions?.nexus?.config.authorize;
+    // If the field doesn't have an authorize field, don't worry about wrapping the resolver
+    if (authorize == null) {
+      return;
+    }
+    // If it does have this field, but it's not a function, it's wrong - let's provide a warning
+    if (typeof authorize !== "function") {
+      console.error(
+        new Error(
+          `The authorize property provided to ${
+            config.fieldConfig.type
+          } should be a function, saw ${typeof authorize}`
+        )
+      );
+      return;
+    }
+    // If they have it, but didn't explicitly specify a plugins array, warn them.
+    if (
+      !config.schemaConfig.plugins?.find(
+        (p) => p.config.name === "NexusAuthorize"
+      )
+    ) {
+      if (!hasWarned) {
+        console.warn(
+          'The GraphQL Nexus "authorize" feature has been moved to a plugin, add [fieldAuthorizePlugin()] to your makeSchema plugin config to remove this warning.'
+        );
+        hasWarned = true;
+      }
+    }
+    // The authorize wrapping resolver.
+    return function(root, args, ctx, info, next) {
+      let toComplete;
+      try {
+        toComplete = authorize(root, args, ctx, info);
+      } catch (e) {
+        toComplete = Promise.reject(e);
+      }
+      return plugin.completeValue(
+        toComplete,
+        (authResult) => {
+          if (authResult === true) {
+            return next(root, args, ctx, info);
+          }
+          const finalFormatError = ensureError(root, args, ctx, info);
+          if (authResult instanceof Error) {
+            finalFormatError(authResult);
+          }
+          if (authResult === false) {
+            finalFormatError(new Error("Not authorized"));
+          }
+          const {
+            fieldName,
+            parentType: { name: parentTypeName },
+          } = info;
+          finalFormatError(
+            new Error(
+              `Nexus authorize for ${parentTypeName}.${fieldName} Expected a boolean or Error, saw ${authResult}`
+            )
+          );
+        },
+        (err) => {
+          ensureError(root, args, ctx, info)(err);
+        }
+      );
+    };
+  };
+
   return plugin({
     name: "NexusAuthorize",
     description:
       "The authorize plugin provides field-level authorization for a schema.",
     fieldDefTypes: fieldDefTypes,
+<<<<<<< HEAD
     onCreateFieldResolver(config) {
       const authorize = config.fieldConfig.extensions?.nexus?.config.authorize;
       // If the field doesn't have an authorize field, don't worry about wrapping the resolver
@@ -152,5 +225,9 @@ export const fieldAuthorizePlugin = (
         );
       };
     },
+=======
+    onCreateFieldSubscribe: authorizationMiddleware,
+    onCreateFieldResolver: authorizationMiddleware,
+>>>>>>> wrap authorization middleware both on onCreateFieldSubscribe and onCreateFieldResolver
   });
 };

--- a/src/plugins/fieldAuthorizePlugin.ts
+++ b/src/plugins/fieldAuthorizePlugin.ts
@@ -84,7 +84,7 @@ export const fieldAuthorizePlugin = (
     config: CreateFieldResolverInfo<any, any>
   ): MiddlewareFn | undefined => {
     const authorize = config.fieldConfig.extensions?.nexus?.config.authorize;
-    // If the field doesn't have an authorize field, don't worry about wrapping the resolver
+    // If the field doesn't have an authorize field, don't worry about wrapping subscribe/resolver
     if (authorize == null) {
       return;
     }
@@ -112,7 +112,7 @@ export const fieldAuthorizePlugin = (
         hasWarned = true;
       }
     }
-    // The authorize wrapping resolver.
+    // The authorize wrapping subscribe/resolver.
     return function(root, args, ctx, info, next) {
       let toComplete;
       try {

--- a/src/plugins/fieldAuthorizePlugin.ts
+++ b/src/plugins/fieldAuthorizePlugin.ts
@@ -93,6 +93,8 @@ export const fieldAuthorizePlugin = (
       console.error(
         new Error(
           `The authorize property provided to ${
+            config.fieldConfig.name
+          } with type ${
             config.fieldConfig.type
           } should be a function, saw ${typeof authorize}`
         )
@@ -155,79 +157,7 @@ export const fieldAuthorizePlugin = (
     description:
       "The authorize plugin provides field-level authorization for a schema.",
     fieldDefTypes: fieldDefTypes,
-<<<<<<< HEAD
-    onCreateFieldResolver(config) {
-      const authorize = config.fieldConfig.extensions?.nexus?.config.authorize;
-      // If the field doesn't have an authorize field, don't worry about wrapping the resolver
-      if (authorize == null) {
-        return;
-      }
-      // If it does have this field, but it's not a function, it's wrong - let's provide a warning
-      if (typeof authorize !== "function") {
-        console.error(
-          new Error(
-            `The authorize property provided to ${
-              config.fieldConfig.name
-            } with type ${
-              config.fieldConfig.type
-            } should be a function, saw ${typeof authorize}`
-          )
-        );
-        return;
-      }
-      // If they have it, but didn't explicitly specify a plugins array, warn them.
-      if (
-        !config.schemaConfig.plugins?.find(
-          (p) => p.config.name === "NexusAuthorize"
-        )
-      ) {
-        if (!hasWarned) {
-          console.warn(
-            'The GraphQL Nexus "authorize" feature has been moved to a plugin, add [fieldAuthorizePlugin()] to your makeSchema plugin config to remove this warning.'
-          );
-          hasWarned = true;
-        }
-      }
-      // The authorize wrapping resolver.
-      return function(root, args, ctx, info, next) {
-        let toComplete;
-        try {
-          toComplete = authorize(root, args, ctx, info);
-        } catch (e) {
-          toComplete = Promise.reject(e);
-        }
-        return plugin.completeValue(
-          toComplete,
-          (authResult) => {
-            if (authResult === true) {
-              return next(root, args, ctx, info);
-            }
-            const finalFormatError = ensureError(root, args, ctx, info);
-            if (authResult instanceof Error) {
-              finalFormatError(authResult);
-            }
-            if (authResult === false) {
-              finalFormatError(new Error("Not authorized"));
-            }
-            const {
-              fieldName,
-              parentType: { name: parentTypeName },
-            } = info;
-            finalFormatError(
-              new Error(
-                `Nexus authorize for ${parentTypeName}.${fieldName} Expected a boolean or Error, saw ${authResult}`
-              )
-            );
-          },
-          (err) => {
-            ensureError(root, args, ctx, info)(err);
-          }
-        );
-      };
-    },
-=======
     onCreateFieldSubscribe: authorizationMiddleware,
     onCreateFieldResolver: authorizationMiddleware,
->>>>>>> wrap authorization middleware both on onCreateFieldSubscribe and onCreateFieldResolver
   });
 };

--- a/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
@@ -143,6 +143,42 @@ declare global {
 }"
 `;
 
+exports[`fieldAuthorizePlugin subscribe field-level authorize fails returning a Promise for an error 1`] = `
+Array [
+  "Guarded error Not authorized",
+]
+`;
+
+exports[`fieldAuthorizePlugin subscribe field-level authorize fails returning a Promise for false 1`] = `
+Array [
+  "Guarded error Not authorized",
+]
+`;
+
+exports[`fieldAuthorizePlugin subscribe field-level authorize fails returning an error 1`] = `
+Array [
+  "Guarded error You shall not pass.",
+]
+`;
+
+exports[`fieldAuthorizePlugin subscribe field-level authorize fails returning false 1`] = `
+Array [
+  "Guarded error Not authorized",
+]
+`;
+
+exports[`fieldAuthorizePlugin subscribe field-level authorize fails throwing an error 1`] = `
+Array [
+  "Guarded error You shall not pass.",
+]
+`;
+
+exports[`fieldAuthorizePlugin subscribe field-level authorize fails with any other value 1`] = `
+Array [
+  "Guarded error Nexus authorize for Subscription.userSubscribeInvalidValue Expected a boolean or Error, saw 1",
+]
+`;
+
 exports[`fieldAuthorizePlugin warns and adds the authorize plugin when a schema has an authorize prop but no plugins 1`] = `
 Array [
   "The GraphQL Nexus \\"authorize\\" feature has been moved to a plugin, add [fieldAuthorizePlugin()] to your makeSchema plugin config to remove this warning.",


### PR DESCRIPTION
Fix #358 

Probably we could make this configurable so consumers can opt-out of validating for subscribe -- although I don't think that'll be very common.