### PR TITLE
fix: run typegen after plugin base setup

### DIFF
--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -62,6 +62,11 @@ export async function runLocalHandOff(): Promise<void> {
   for (const p of plugins) {
     await p.hooks.create.onAfterBaseSetup?.({ database, connectionURI })
   }
+
+  //
+  // format project
+  //
+  await layout.packageManager.runScript('format', { require: true })
 }
 
 /**
@@ -217,12 +222,6 @@ export async function runBootstrapper(
   //
   // return to global create
   //
-
-  //
-  // format project and setup git
-  //
-
-  await layout.packageManager.runScript('format', { require: true })
 
   // Any disk changes after this point will show up as dirty working directory
   // for the user


### PR DESCRIPTION
## Description

Looks like an update of prettier made it fail when a pattern doesn't match any file.
This PR makes prettier run only after the plugins have run their base setup, which makes sense anyway.