### PR TITLE
refactor(schema): reduce indirection

### DIFF
--- a/src/lib/nexus-schema-stateful/stateful-nexus-schema.ts
+++ b/src/lib/nexus-schema-stateful/stateful-nexus-schema.ts
@@ -118,7 +118,6 @@ export function createNexusSchemaStateful() {
   const booleanArg = NexusSchema.booleanArg
 
   return {
-    makeSchemaInternal: makeSchemaInternal,
     state: state,
     builders: {
       queryType,

--- a/src/lib/nexus-schema-stateful/stateful-nexus-schema.ts
+++ b/src/lib/nexus-schema-stateful/stateful-nexus-schema.ts
@@ -40,11 +40,6 @@ export function createNexusSchemaStateful() {
     types: [],
   }
 
-  function makeSchemaInternal(config: NexusSchema.core.SchemaConfig) {
-    config.types.push(state.types)
-    return NexusSchema.core.makeSchemaInternal(config)
-  }
-
   function objectType<TypeName extends string>(
     config: CustomTypes.NexusObjectTypeConfig<TypeName>
   ): NexusSchema.core.NexusObjectTypeDef<TypeName> {

--- a/src/runtime/schema/schema.ts
+++ b/src/runtime/schema/schema.ts
@@ -1,4 +1,5 @@
 import * as NexusSchema from '@nexus/schema'
+import { makeSchemaInternal } from '@nexus/schema/dist/core'
 import * as HTTP from 'http'
 import * as Layout from '../../lib/layout'
 import * as Logger from '../../lib/logger'
@@ -71,11 +72,13 @@ export function create(): SchemaInternal {
           plugins,
           state.settings
         )
-        const {
-          schema,
-          missingTypes,
-          finalConfig,
-        } = statefulNexusSchema.makeSchemaInternal(nexusSchemaConfig)
+
+        nexusSchemaConfig.types.push(...statefulNexusSchema.state.types)
+
+        const { schema, missingTypes, finalConfig } = makeSchemaInternal(
+          nexusSchemaConfig
+        )
+
         if (nexusSchemaConfig.shouldGenerateArtifacts === true) {
           const devModeLayout = await Layout.loadDataFromParentProcess()
 


### PR DESCRIPTION
Stateful nexus schema is better focused now. It doesn't need to control the make schema part. Just the accumulation of types.