### PR TITLE
refactor: build module facades on the fly

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -78,6 +78,7 @@ jobs:
         id: release
         run: |
           cat published/result.json | jq -r '.version'
+          cat published/result.json | jq -r
           echo ::set-output name=result::$(jq -r '.kind' <<< $result)
       - uses: actions/checkout@v2
         if: steps.release.outputs.result == 'did_publish'

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ dist
 tsconfig.tsbuildinfo
 
 .now
+
+# module facades
+/testing.d.ts
+/testing.js
+/plugin.d.ts
+/plugin.js

--- a/components/schema.d.ts
+++ b/components/schema.d.ts
@@ -1,1 +1,1 @@
-export * from '../dist/components/schema'
+export * from './dist/components/schema'

--- a/components/schema.js
+++ b/components/schema.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/components/schema')
+module.exports = require('./dist/components/schema')

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "release:preview": "dripip preview",
     "release:pr": "dripip pr",
     "format": "prettier --write '*/**/*.ts'",
-    "build": "yarn -s clean && tsc -b",
+    "build": "yarn -s clean && node scripts/build-module-facades && tsc -b",
     "clean": "git clean -fX && rm -rf dist",
     "postpublish": "yarn -s clean",
     "postinstall": "node scripts/postinstall",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "release:pr": "dripip pr",
     "format": "prettier --write '*/**/*.ts'",
     "build": "yarn -s clean && tsc -b",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "git clean -fX && rm -rf dist",
     "postpublish": "yarn -s clean",
     "postinstall": "node scripts/postinstall",
     "prepublishOnly": "yarn -s build",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "test:e2e": "DEBUG=true jest --verbose --testTimeout 360000 test/e2e",
     "test:system": "LINK=true DEBUG=true jest --verbose --testTimeout 360000 test/system",
     "dev:test": "jest --watch --testRegex '.+/src/.+\\.spec\\.ts$'",
-    "dev": "tsc -b -w"
+    "dev": "yarn -s clean && node scripts/build-module-facades && tsc -b -w"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "testing.d.ts",
     "testing.js",
     "plugin.d.ts",
-    "plugin.js"
+    "plugin.js",
+    "components/schema.d.ts",
+    "components/schema.js"
   ],
   "bin": {
     "nexus": "dist/cli/main.js"

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/plugin'

--- a/plugin.js
+++ b/plugin.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/plugin')

--- a/scripts/build-module-facades.js
+++ b/scripts/build-module-facades.js
@@ -29,8 +29,8 @@ const facades = [
   ['testing.js', "module.exports = require('./dist/testing')"],
   ['plugin.d.ts', "export * from './dist/plugin'"],
   ['plugin.js', "module.exports = require('./dist/plugin')"],
-  ['components/schema.d.ts', "export * from './dist/components/schema'"],
-  ['components/schema.js', "module.exports = require('./dist/components/schema')"],
+  ['components/schema.d.ts', "export * from '../dist/components/schema'"],
+  ['components/schema.js', "module.exports = require('../dist/components/schema')"],
 ]
 
 // Write facade files

--- a/scripts/build-module-facades.js
+++ b/scripts/build-module-facades.js
@@ -1,0 +1,50 @@
+/**
+ * Module Facades
+ *
+ * This script builds the modules that will be consumed publically. They front
+ * the actual code inside ./dist. The problem being solved here is that it
+ * allows consumers to do e.g. this:
+ *
+ *    import { ... } from 'nexus/testing'
+ *
+ * Instead of:
+ *
+ *    import { ... } from 'nexus/dist/testing'
+ *
+ * Whatever modules are written here should be ignored in .gitignore.
+ */
+
+const fs = require('fs-jetpack')
+const { stripIndent } = require('common-tags')
+
+// testing
+
+fs.write(
+  'testing.d.ts',
+  stripIndent`
+    export * from './dist/testing'
+  `
+)
+
+fs.write(
+  'testing.js',
+  stripIndent`
+    module.exports = require('./dist/testing')
+  `
+)
+
+// plugin
+
+fs.write(
+  'plugin.d.ts',
+  stripIndent`
+    export * from './dist/plugin'
+  `
+)
+
+fs.write(
+  'plugin.js',
+  stripIndent`
+    module.exports = require('./dist/plugin')
+  `
+)

--- a/scripts/build-module-facades.js
+++ b/scripts/build-module-facades.js
@@ -25,12 +25,14 @@ const { stripIndent } = require('common-tags')
 
 // prettier-ignore
 const facades = [
-  ['testing.d.ts', "export * from './dist/testing'"],
-  ['testing.js', "module.exports = require('./dist/testing')"],
-  ['plugin.d.ts', "export * from './dist/plugin'"],
-  ['plugin.js', "module.exports = require('./dist/plugin')"],
-  ['components/schema.d.ts', "export * from '../dist/components/schema'"],
-  ['components/schema.js', "module.exports = require('../dist/components/schema')"],
+  ['testing.d.ts',            "export * from './dist/testing'"                        + os.EOL],
+  ['testing.js',              "module.exports = require('./dist/testing')"            + os.EOL],
+
+  ['plugin.d.ts',             "export * from './dist/plugin'"                         + os.EOL],
+  ['plugin.js',               "module.exports = require('./dist/plugin')"             + os.EOL],
+
+  ['components/schema.d.ts',  "export * from '../dist/components/schema'"             + os.EOL],
+  ['components/schema.js',    "module.exports = require('../dist/components/schema')" + os.EOL],
 ]
 
 // Write facade files

--- a/scripts/build-module-facades.js
+++ b/scripts/build-module-facades.js
@@ -28,7 +28,9 @@ const facades = [
   ['testing.d.ts', "export * from './dist/testing'"],
   ['testing.js', "module.exports = require('./dist/testing')"],
   ['plugin.d.ts', "export * from './dist/plugin'"],
-  ['plugin.js', "module.exports = require('./dist/plugin')"]
+  ['plugin.js', "module.exports = require('./dist/plugin')"],
+  ['components/schema.d.ts', "export * from './dist/components/schema'"],
+  ['components/schema.js', "module.exports = require('./dist/components/schema')"],
 ]
 
 // Write facade files

--- a/testing.d.ts
+++ b/testing.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/testing'

--- a/testing.js
+++ b/testing.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/testing')


### PR DESCRIPTION
This cleans up the package facade system. It is easier to manage now because the pattern in use is centrally readable and changeable. We also remove noise from the project, as the facades aren't meaningful for our development, and so shouldn't be visible in our day to day work.

Cleaning before dev is also good. It removes the possibility of stale buildinfo making tsc incremental build act weird (which I've had happen to myself multiple times a week).