### PR TITLE
feat: remove future term from global interface

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -23,7 +23,7 @@ export function createTestContext(): TestContext {
   let ctx: TestContext
 
   beforeAll(async () => {
-    ctx = await createTestContext()
+    ctx = await originalCreateTestContext()
     await ctx.app.server.start()
   })
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -17,7 +17,7 @@ Before jumping into test suites we will wrap the `createTestContext` with a patt
 
 ```ts
 // tests/__helpers.ts
-import { createTestContext, TestContext } from 'nexus/testing'
+import { createTestContext as originalCreateTestContext, TestContext } from 'nexus/testing'
 
 export function createTestContext(): TestContext {
   let ctx: TestContext
@@ -31,6 +31,7 @@ export function createTestContext(): TestContext {
     await ctx.app.server.stop()
   })
 
+  // @ts-ignore
   return ctx
 }
 ```

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -33,14 +33,14 @@ export interface TestContextCore {
 }
 
 declare global {
-  interface nexusFutureTestContextApp extends TestContextAppCore {}
+  interface NexusTestContextApp extends TestContextAppCore {}
 
-  interface nexusFutureTestContextRoot {
-    app: nexusFutureTestContextApp
+  interface NexusTestContextRoot {
+    app: NexusTestContextApp
   }
 }
 
-export type TestContext = nexusFutureTestContextRoot
+export type TestContext = NexusTestContextRoot
 
 /**
  * Setup a test context providing utilities to query against your GraphQL API


### PR DESCRIPTION
BREAKING CHANGE:

Extending the testing context interface type must now be done using name
`NexusTestContextApp` instead of `nexusFutureTestContextApp`.

We need to update Prisma plugin.