### PR TITLE
fix: vscode debugging

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
 - [Conventions](guides/conventions)
 - [Error Handling](guides/error-handling)
 - [Plugins](guides/plugins)
+- [Debugging](guides/debugging)
 - [Recipes](references/recipes)
 - [Writing Plugins](guides/writing-plugins)
 

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,0 +1,38 @@
+### With VS Code
+
+We made it very simple to debug your app with VS Code.
+
+> Note: If you used `npx nexus` to initialize your project, jump straight to step 2.
+
+1. Create a `.vscode/launch.json` file and paste the following content
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Nexus App",
+      "protocol": "inspector",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/nexus",
+      "runtimeArgs": ["dev"],
+      "sourceMaps": true,
+      "console": "integratedTerminal"
+    }
+  ]
+}
+```
+
+2. Click on the `Run` tab on the left side of VS Code
+
+3. Make sure `Debug Nexus App` is selected in the dropdown located at the top of the panel that the `Run` tab opened
+
+4. Set some breaking points where you want to inspect your code
+
+5. Click the green "Start debugging" button located next to the dropdown
+
+6. That's it. VS Code should run your code and stop wherever your set some breakpoints
+
+
+

--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -509,7 +509,7 @@ async function scaffoldBaseFiles(options: InternalConfig) {
             {
               "type": "node",
               "request": "launch",
-              "name": "Debug nexus App",
+              "name": "Debug Nexus App",
               "protocol": "inspector",
               "runtimeExecutable": "\${workspaceRoot}/node_modules/.bin/nexus",
               "runtimeArgs": ["dev"],

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -60,6 +60,7 @@ export class Dev implements Command {
     }
 
     await createWatcher({
+      inspectBrk: args["--inspect-brk"],
       plugins: [layoutPlugin].concat(plugins.map((p) => p.hooks)),
       sourceRoot: layout.sourceRoot,
     })

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -10,7 +10,7 @@ import { createWatcher } from '../../lib/watcher'
 const log = rootLogger.child('dev')
 
 const DEV_ARGS = {
-  '--inspect-brk': Number,
+  '--inspect-brk': String,
 }
 
 export class Dev implements Command {

--- a/src/lib/watcher/link.ts
+++ b/src/lib/watcher/link.ts
@@ -13,9 +13,9 @@ interface Options extends ChangeableOptions {
   onRunnerImportedModule?: (data: ModuleRequiredMessage['data']) => void
   onServerListening?: () => void
   /**
-   * Port on which the debugger should listen to 
+   * Host and/or port on which the debugger should listen to
    */
-  inspectBrk?: number
+  inspectBrk?: string
 }
 
 export class Link {
@@ -103,7 +103,7 @@ export class Link {
     const forkCmd: string[] = []
 
     if (this.options.inspectBrk) {
-      forkCmd.push(`--inspect-brk=${this.options.inspectBrk.toString()}`)
+      forkCmd.push(`--inspect-brk=${this.options.inspectBrk}`)
     }
 
     forkCmd.push(require.resolve('./runner'))

--- a/src/lib/watcher/link.ts
+++ b/src/lib/watcher/link.ts
@@ -12,6 +12,10 @@ interface ChangeableOptions {
 interface Options extends ChangeableOptions {
   onRunnerImportedModule?: (data: ModuleRequiredMessage['data']) => void
   onServerListening?: () => void
+  /**
+   * Port on which the debugger should listen to 
+   */
+  inspectBrk?: number
 }
 
 export class Link {
@@ -96,7 +100,17 @@ export class Link {
       throw new Error('attempt to spawn while previous child process still exists')
     }
 
-    this.childProcess = nodecp.fork(require.resolve('./runner'), [], {
+    const forkCmd: string[] = []
+
+    if (this.options.inspectBrk) {
+      forkCmd.push(`--inspect-brk=${this.options.inspectBrk.toString()}`)
+    }
+
+    forkCmd.push(require.resolve('./runner'))
+
+    const [firstArg, ...rest] = forkCmd
+
+    this.childProcess = nodecp.fork(firstArg, rest, {
       cwd: process.cwd(),
       stdio: 'pipe',
       env: {

--- a/src/lib/watcher/types.ts
+++ b/src/lib/watcher/types.ts
@@ -60,7 +60,7 @@ export interface Opts extends BooleanOpts, StringOpts {
   stdio?: ForkOptions['stdio']
   plugins: Plugin.WorktimeHooks[]
   /**
-   * Port on which the debugger should listen to
+   * Host and/or port on which the debugger should listen to
    */
-  inspectBrk?: number
+  inspectBrk?: string
 }

--- a/src/lib/watcher/types.ts
+++ b/src/lib/watcher/types.ts
@@ -59,4 +59,8 @@ export interface Opts extends BooleanOpts, StringOpts {
   watch?: string
   stdio?: ForkOptions['stdio']
   plugins: Plugin.WorktimeHooks[]
+  /**
+   * Port on which the debugger should listen to
+   */
+  inspectBrk?: number
 }

--- a/src/lib/watcher/watcher.ts
+++ b/src/lib/watcher/watcher.ts
@@ -51,6 +51,7 @@ export function createWatcher(options: Options): Promise<void> {
 
         watcher.resume()
       },
+      inspectBrk: options.inspectBrk,
     })
 
     process.onBeforeExit(() => {


### PR DESCRIPTION
Fixes a regression. `--inspect-brk` is passed to `fork` again in the watcher

#### TODO

- [x] docs
- [ ] tests
