### PR TITLE
fix: enforce @now/node builder

### DIFF
--- a/src/lib/build/deploy-target.ts
+++ b/src/lib/build/deploy-target.ts
@@ -91,7 +91,7 @@ function validateNow(layout: Layout): ValidatorResult {
         "builds": [
           {
             "src": "${startModulePath}",
-            "use": "@now/node-server"
+            "use": "@now/node"
           }
         ],
         "routes": [{ "src": "/.*", "dest": "${startModulePath}" }]
@@ -106,11 +106,11 @@ function validateNow(layout: Layout): ValidatorResult {
     // Make sure the now.json file has the right `builds` values
     if (
       !nowJson.builds ||
-      !nowJson.builds.find((build) => build.src === startModulePath && build.use === '@now/node-server')
+      !nowJson.builds.find((build) => build.src === startModulePath && build.use === '@now/node')
     ) {
       log.error(`We could not find a proper builder in your \`now.json\` file`)
       log.error(`Found: "builds": ${JSON.stringify(nowJson.builds)}`)
-      log.error(`Expected: "builds": [{ src: "${startModulePath}", use: '@now/node-server' }, ...]`)
+      log.error(`Expected: "builds": [{ src: "${startModulePath}", use: '@now/node' }, ...]`)
       console.log('\n')
       isValid = false
     }


### PR DESCRIPTION
Unfortunately, I was unable to get a proper now deployment with the suggested @now/node-server build, it always broke.

After some fiddling around, and as a workaround until the now-nexus builder in working, I worked out that patching the build command worked.

In my `now.json`:

```json
{
 "builds": [{ "src": "dist/index.js", "use": "@now/node" }],
 "routes": [{ "src": "/.*", "dest": "dist/index.js" }]
}
```

And I also found out that the `@now/node-server` builder has been deprecated in favour of the `@now/node` builder. 
