### PR TITLE
fix: better heuristic to detect nexus global cli usage

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -39,7 +39,7 @@ async function guardNotGlobalCLIWithLocalProject(
   // TODO data is attainable from layout scan calculated later on... not optimal to call this twice...
   const projectType = await Layout.scanProjectType({ cwd: process.cwd() })
 
-  if (projectType.type === 'NEXUS_project' && isProcessFromProjectBin(projectType.packageJsonLocation.path)) {
+  if (projectType.type === 'NEXUS_project' && isProcessFromProjectBin(projectType.packageJsonLocation.path) === false) {
     // TODO make npm aware
     fatal(stripIndent`
         You are using the nexus cli from a location other than this project.

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -234,11 +234,11 @@ export function isProcessFromProjectBin(packageJsonPath: string): boolean {
   const realProcessBinPath = fs.realpathSync(process.argv[1])
   
   if (!fs.existsSync(projectBinPath)) {
-    log.trace('Nexus project bin path not found. A global CLI could be used with a wrong version', {
+    log.warn('Nexus project bin path not found. A global CLI could be used with a wrong version', {
       projectBinPath,
       processBinPath: realProcessBinPath,
     })
-    
+
     return true
   }
 


### PR DESCRIPTION
closes #526 

We now follow the symlink of the executed bin path (`argv[1]`) and compare it to the supposed location of the `nexus` bin.

Note: I believe this method won't work for yarn workspaces. The "supposed location" of the nexus bin might wrong if the nexus bin path is hoisted to the parent directory.
In that case, we just fallback and assume the right cli is used.

There's unfortunately no good api to find the bin of a package as this is a pure invention of npm as explained here: https://github.com/nodejs/help/issues/388

PR release: `nexus@pr.657`