### PR TITLE
feat(server): add playground.path configuration

### DIFF
--- a/docs/api/modules/main/exports/settings.md
+++ b/docs/api/modules/main/exports/settings.md
@@ -15,7 +15,7 @@ Use the settings to centrally configure various aspects of the various component
     port?: number
     host?: string
     path?: string
-    playground?: boolean
+    playground?: boolean | { path?: string }
   }
   schema?: {
     nullable?: {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "jest": "25.2.7",
     "node-pty": "0.9.0",
     "prettier": "2.0.4",
-    "ts-jest": "25.3.1"
+    "ts-jest": "25.3.1",
+    "utility-types": "^3.10.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/lib/plugin/types/lens.ts
+++ b/src/lib/plugin/types/lens.ts
@@ -1,5 +1,6 @@
 import * as NexusSchema from '@nexus/schema'
 import * as Prompts from 'prompts'
+import { DeepPartial } from 'utility-types'
 import * as Testing from '../../../runtime/testing'
 import * as Layout from '../../layout'
 import * as Logger from '../../logger'
@@ -133,7 +134,7 @@ export type RuntimeContributions<C extends {} = any> = {
   }
 }
 
-export type TesttimeContributions = Utils.DeepPartial<Testing.TestContextCore>
+export type TesttimeContributions = DeepPartial<Testing.TestContextCore> & { [prop: string]: any }
 
 export type Lens = {
   log: Logger.Logger

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -189,3 +189,14 @@ export function partition<T>(array: Array<T>, predicate: (value: T) => boolean):
 
   return partitioned
 }
+
+/**
+ * Render IPv6 `::` as localhost. By default Node servers will use :: if IPv6
+ * host is available otherwise IPv4 0.0.0.0. In local development it seems that
+ * rendering as localhost makes the most sense as to what the user expects.
+ * According to Node docs most operating systems that are supporting IPv6
+ * somehow bind `::` to `0.0.0.0` anyways.
+ */
+export function prettifyHost(host: string): string {
+  return host === '::' ? 'localhost' : host
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -6,10 +6,6 @@ export type SideEffector = () => MaybePromise
 
 export type Param1<F> = F extends (p: infer P, ...args: any[]) => any ? P : never
 
-export type DeepPartial<T extends Record<string, any>> = {
-  [P in keyof T]?: T[P] extends Record<string, any> ? DeepPartial<T[P]> : T[P]
-} & { [x: string]: any }
-
 /**
  * Guarantee the length of a given string, padding before or after with the
  * given character. If the given string is longer than  the span target, then it

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -39,13 +39,13 @@ export interface App {
 type SettingsInput = {
   logger?: Logger.SettingsInput
   schema?: Schema.SettingsInput
-  server?: Server.ExtraSettingsInput
+  server?: Server.SettingsInput
 }
 
 export type SettingsData = Readonly<{
   logger: Logger.SettingsData
   schema: Schema.SettingsData
-  server: Server.ExtraSettingsData
+  server: Server.SettingsData
 }>
 
 /**
@@ -96,18 +96,18 @@ export function create(): App {
         schemaComponent.private.settings.change(newSettings.schema)
       }
       if (newSettings.server) {
-        Object.assign(settings.current.server, newSettings.server)
+        server.settings.change(newSettings.server)
       }
     },
     current: {
       logger: log.settings,
       schema: schemaComponent.private.settings.data,
-      server: Server.defaultExtraSettingsInput,
+      server: server.settings.data,
     },
     original: Lo.cloneDeep({
       logger: log.settings,
       schema: schemaComponent.private.settings.data,
-      server: Server.defaultExtraSettingsInput,
+      server: server.settings.data,
     }),
   }
 
@@ -142,11 +142,10 @@ export function create(): App {
         __state.isWasServerStartCalled = true
 
         const plugins = await Plugin.loadRuntimePluginsFromEntrypoints(__state.plugins)
-        const graphqlSchema = await schemaComponent.private.makeSchema(plugins)
+        const schema = await schemaComponent.private.makeSchema(plugins)
 
         await server.setupAndStart({
-          settings: settings,
-          schema: graphqlSchema,
+          schema,
           plugins,
           contextContributors: schemaComponent.private.state.contextContributors,
         })

--- a/src/runtime/schema/settings.ts
+++ b/src/runtime/schema/settings.ts
@@ -6,7 +6,9 @@ import { isAbsolute } from 'path'
 import { mustLoadDataFromParentProcess } from '../../lib/layout/layout'
 import * as Plugin from '../../lib/plugin'
 import { Param1 } from '../../lib/utils'
-import { log } from './logger'
+import { log as schemaLogger } from './logger'
+
+const log = schemaLogger.child('settings')
 
 type NexusSchemaConfig = NexusSchema.core.SchemaConfig
 

--- a/src/runtime/server/index.ts
+++ b/src/runtime/server/index.ts
@@ -1,0 +1,2 @@
+export { create, Server } from './server'
+export { SettingsData, SettingsInput } from './settings'

--- a/src/runtime/server/logger.ts
+++ b/src/runtime/server/logger.ts
@@ -1,0 +1,3 @@
+import * as Logger from '../../lib/logger'
+
+export const log = Logger.create({ name: 'server' })

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -193,7 +193,7 @@ export function create(): ServerFactory {
   const express = createExpress()
   let server: BaseServer | null = null
   const state = {
-    settings: ServerSettings.defaultSettings,
+    settings: ServerSettings.defaultSettings(),
   }
 
   return {

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -4,103 +4,19 @@ import * as GraphQL from 'graphql'
 import * as HTTP from 'http'
 import * as Net from 'net'
 import stripAnsi from 'strip-ansi'
-import * as Logger from '../lib/logger'
-import * as Plugin from '../lib/plugin'
-import * as App from './app'
-import * as DevMode from './dev-mode'
-import * as Utils from '../lib/utils'
+import * as Logger from '../../lib/logger'
+import * as Plugin from '../../lib/plugin'
+import * as Utils from '../../lib/utils'
+import * as DevMode from '../dev-mode'
+import { log } from './logger'
+import * as ServerSettings from './settings'
 
 // Avoid forcing users to use esModuleInterop
 const createExpressGraphql = ExpressGraphQL.default
+const resolverLogger = log.child('graphql')
 
 type Request = HTTP.IncomingMessage & { log: Logger.Logger }
 type ContextContributor<T extends {}> = (req: Request) => Utils.MaybePromise<T>
-
-const log = Logger.create({ name: 'server' })
-const resolverLogger = log.child('graphql')
-
-type DefaultExtraSettingsInput = Required<Omit<ExtraSettingsInput, 'host'>> & Pick<ExtraSettingsInput, 'host'>
-
-/**
- * Render IPv6 `::` as localhost. By default Node servers will use :: if IPv6
- * host is available otherwise IPv4 0.0.0.0. In local development it seems that
- * rendering as localhost makes the most sense as to what the user expects.
- * According to Node docs most operating systems that are supporting IPv6
- * somehow bind `::` to `0.0.0.0` anyways.
- */
-function prettifyHost(host: string): string {
-  return host === '::' ? 'localhost' : host
-}
-
-/**
- * The default server options. These are merged with whatever you provide. Your
- * settings take precedence over these.
- */
-export const defaultExtraSettingsInput: DefaultExtraSettingsInput = {
-  host: process.env.NEXUS_HOST || process.env.HOST || undefined,
-  port:
-    typeof process.env.NEXUS_PORT === 'string'
-      ? parseInt(process.env.NEXUS_PORT, 10)
-      : typeof process.env.PORT === 'string'
-      ? // e.g. Heroku convention https://stackoverflow.com/questions/28706180/setting-the-port-for-node-js-server-on-heroku
-        parseInt(process.env.PORT, 10)
-      : process.env.NODE_ENV === 'production'
-      ? 80
-      : 4000,
-  startMessage: ({ port, host }): void => {
-    log.info('listening', { url: `http://${prettifyHost(host)}:${port}` })
-  },
-  playground: process.env.NODE_ENV === 'production' ? false : true,
-  path: '/graphql',
-}
-
-export type ExtraSettingsInput = {
-  /**
-   * todo
-   */
-  port?: number
-  /**
-   * Host the server should be listening on.
-   */
-  host?: string
-  /**
-   * Should GraphQL Playground be hosted by the server?
-   *
-   * @default `false` in production, `true` otherwise
-   *
-   * @remarks
-   *
-   * Useful during development as a visual client to interact with your API. In
-   * production, without some kind of security/access control, you will almost
-   * certainly want this disabled.
-   *
-   * To learn more about GraphQL Playgorund see
-   * https://github.com/prisma-labs/graphql-playground
-   */
-  playground?: boolean
-  /**
-   * The path on which the GraphQL API should be served.
-   *
-   * @default
-   * /graphql
-   */
-  path?: string
-  /**
-   * Create a message suitable for printing to the terminal about the server
-   * having been booted.
-   */
-  startMessage?: (address: { port: number; host: string; ip: string }) => void
-}
-
-export type ExtraSettingsData = DefaultExtraSettingsInput
-
-/**
- * The available server options to configure how your app runs its server.
- */
-export type SettingsInput = ExpressGraphQL.OptionsData &
-  ExtraSettingsInput & {
-    context: ContextCreator
-  }
 
 export type ExpressInstance = Omit<Express, 'listen'>
 
@@ -129,17 +45,21 @@ export interface Server extends BaseServer {
   express: ExpressInstance
 }
 
-function setupExpress(express: Express, settings: SettingsInput): BaseServer {
+export type SetupExpressInput = ExpressGraphQL.OptionsData &
+  ServerSettings.SettingsData & {
+    context: ContextCreator
+  }
+
+function setupExpress(express: Express, settings: SetupExpressInput): BaseServer {
   const http = HTTP.createServer()
-  const settingsMerged = { ...defaultExtraSettingsInput, ...settings }
 
   http.on('request', express)
 
   express.use(
-    settingsMerged.path,
+    settings.path,
     createExpressGraphql((req) => {
-      return settingsMerged.context(req).then((resolvedCtx) => ({
-        ...settingsMerged,
+      return settings.context(req).then((resolvedCtx) => ({
+        ...settings,
         context: resolvedCtx,
         customFormatErrorFn: (error: Error) => {
           const colorlessMessage = stripAnsi(error.message)
@@ -159,9 +79,8 @@ function setupExpress(express: Express, settings: SettingsInput): BaseServer {
       }))
     })
   )
-
-  if (settingsMerged.playground) {
-    express.get('/', (_req, res) => {
+  if (settings.playground) {
+    express.get(settings.playground.path, (_req, res) => {
       res.send(`
         <!DOCTYPE html>
         <html>
@@ -215,7 +134,7 @@ function setupExpress(express: Express, settings: SettingsInput): BaseServer {
           </div>
           <script>window.addEventListener('load', function (event) {
               GraphQLPlayground.init(document.getElementById('root'), {
-                endpoint: '${settingsMerged.path}'
+                endpoint: '${settings.path}'
               })
             })</script>
         </body>
@@ -228,15 +147,17 @@ function setupExpress(express: Express, settings: SettingsInput): BaseServer {
   return {
     start: () =>
       new Promise<void>((res) => {
-        http.listen({ port: settingsMerged.port, host: settingsMerged.host }, () => {
+        http.listen({ port: settings.port, host: settings.host }, () => {
           // - We do not support listening on unix domain sockets so string
           //   value will never be present here.
           // - We are working within the listen callback so address will not be null
           const address = http.address()! as Net.AddressInfo
-          settingsMerged.startMessage({
+          settings.startMessage({
             port: address.port,
             host: address.address,
             ip: address.address,
+            path: settings.path,
+            playgroundPath: settings.playground ? settings.playground.path : undefined,
           })
           res()
         })
@@ -259,15 +180,21 @@ interface ServerFactory {
     schema: GraphQL.GraphQLSchema
     plugins: Plugin.RuntimeContributions[]
     contextContributors: ContextContributor<any>[]
-    settings: App.Settings
   }): Promise<void>
   stop(): Promise<void>
   express: ExpressInstance
+  settings: {
+    change(settings: ServerSettings.SettingsInput): void
+    data: ServerSettings.SettingsData
+  }
 }
 
 export function create(): ServerFactory {
   const express = createExpress()
   let server: BaseServer | null = null
+  const state = {
+    settings: ServerSettings.defaultSettings,
+  }
 
   return {
     express,
@@ -275,12 +202,12 @@ export function create(): ServerFactory {
       schema: GraphQL.GraphQLSchema
       plugins: Plugin.RuntimeContributions[]
       contextContributors: ContextContributor<any>[]
-      settings: App.Settings
     }) {
       const context = contextFactory(opts.contextContributors, opts.plugins)
 
       server = setupExpress(express, {
-        ...opts,
+        ...state.settings,
+        schema: opts.schema,
         context,
       })
 
@@ -295,6 +222,12 @@ export function create(): ServerFactory {
       }
 
       return server.stop()
+    },
+    settings: {
+      change(newSettings) {
+        state.settings = ServerSettings.changeSettings(state.settings, newSettings)
+      },
+      data: state.settings,
     },
   }
 }

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -1,8 +1,6 @@
 import { DeepRequired } from 'utility-types'
 import { fatal } from '../../lib/process'
-import { log as serverLogger } from './logger'
-
-const log = serverLogger.child('settings')
+import { log } from './logger'
 
 export type PlaygroundSettings = {
   path?: string

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -1,5 +1,6 @@
-import { DeepRequired } from 'utility-types'
-import { fatal } from '../../lib/process'
+import * as UtilityTypes from 'utility-types'
+import * as Process from '../../lib/process'
+import * as Utils from '../../lib/utils'
 import { log as serverLogger } from './logger'
 
 const log = serverLogger.child('settings')
@@ -52,47 +53,41 @@ export type SettingsInput = {
   }) => void
 }
 
-export type SettingsData = Omit<DeepRequired<SettingsInput>, 'host' | 'playground'> & {
+export type SettingsData = Omit<UtilityTypes.DeepRequired<SettingsInput>, 'host' | 'playground'> & {
   host: string | undefined
   playground: false | Required<PlaygroundSettings>
 }
 
 export const defaultPlaygroundPath = '/'
-export const defaultPlaygroundSettings: Readonly<Required<PlaygroundSettings>> = Object.freeze({
-  path: defaultPlaygroundPath,
-})
+export const defaultPlaygroundSettings: () => Readonly<Required<PlaygroundSettings>> = () =>
+  Object.freeze({
+    path: defaultPlaygroundPath,
+  })
 
 /**
  * The default server options. These are merged with whatever you provide. Your
  * settings take precedence over these.
  */
-export const defaultSettings: Readonly<SettingsData> = Object.freeze({
-  host: process.env.NEXUS_HOST ?? process.env.HOST ?? undefined,
-  port:
-    typeof process.env.NEXUS_PORT === 'string'
-      ? parseInt(process.env.NEXUS_PORT, 10)
-      : typeof process.env.PORT === 'string'
-      ? // e.g. Heroku convention https://stackoverflow.com/questions/28706180/setting-the-port-for-node-js-server-on-heroku
-        parseInt(process.env.PORT, 10)
-      : process.env.NODE_ENV === 'production'
-      ? 80
-      : 4000,
-  startMessage: ({ port, host, path, playgroundPath }): void => {
-    serverLogger.info('listening', { url: `http://${prettifyHost(host)}:${port}${playgroundPath ?? path}` })
-  },
-  playground: process.env.NODE_ENV === 'production' ? false : defaultPlaygroundSettings,
-  path: '/graphql',
-})
-
-/**
- * Render IPv6 `::` as localhost. By default Node servers will use :: if IPv6
- * host is available otherwise IPv4 0.0.0.0. In local development it seems that
- * rendering as localhost makes the most sense as to what the user expects.
- * According to Node docs most operating systems that are supporting IPv6
- * somehow bind `::` to `0.0.0.0` anyways.
- */
-function prettifyHost(host: string): string {
-  return host === '::' ? 'localhost' : host
+export const defaultSettings: () => Readonly<SettingsData> = () => {
+  return Object.freeze({
+    host: process.env.NEXUS_HOST ?? process.env.HOST ?? undefined,
+    port:
+      typeof process.env.NEXUS_PORT === 'string'
+        ? parseInt(process.env.NEXUS_PORT, 10)
+        : typeof process.env.PORT === 'string'
+        ? // e.g. Heroku convention https://stackoverflow.com/questions/28706180/setting-the-port-for-node-js-server-on-heroku
+          parseInt(process.env.PORT, 10)
+        : process.env.NODE_ENV === 'production'
+        ? 80
+        : 4000,
+    startMessage: ({ port, host, path, playgroundPath }): void => {
+      serverLogger.info('listening', {
+        url: `http://${Utils.prettifyHost(host)}:${port}${playgroundPath ?? path}`,
+      })
+    },
+    playground: process.env.NODE_ENV === 'production' ? false : defaultPlaygroundSettings(),
+    path: '/graphql',
+  } as SettingsData)
 }
 
 function playgroundPath(settings: true | PlaygroundSettings): string {
@@ -105,7 +100,7 @@ function playgroundPath(settings: true | PlaygroundSettings): string {
   }
 
   if (settings.path.length === 0) {
-    fatal('Custom playground `path` cannot be empty and must start with a "/"')
+    Process.fatal('Custom playground `path` cannot be empty and must start with a "/"')
   }
 
   if (settings.path.startsWith('/') === false) {
@@ -131,7 +126,7 @@ function validateGraphQLPath(path: string): string {
   let outputPath = path
 
   if (path.length === 0) {
-    fatal('Custom GraphQL `path` cannot be empty and must start with a /')
+    Process.fatal('Custom GraphQL `path` cannot be empty and must start with a /')
   }
 
   if (path.startsWith('/') === false) {

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -1,0 +1,156 @@
+import { DeepRequired } from 'utility-types'
+import { fatal } from '../../lib/process'
+import { log as serverLogger } from './logger'
+
+const log = serverLogger.child('settings')
+
+export type PlaygroundSettings = {
+  path?: string
+}
+
+export type SettingsInput = {
+  /**
+   * todo
+   */
+  port?: number
+  /**
+   * Host the server should be listening on.
+   */
+  host?: string | undefined
+  /**
+   * Should GraphQL Playground be hosted by the server?
+   *
+   * @default `false` in production, `{ path: '/' }` otherwise
+   *
+   * @remarks
+   *
+   * Useful during development as a visual client to interact with your API. In
+   * production, without some kind of security/access control, you will almost
+   * certainly want this disabled.
+   *
+   * To learn more about GraphQL Playgorund see
+   * https://github.com/prisma-labs/graphql-playground
+   */
+  playground?: boolean | PlaygroundSettings
+  /**
+   * The path on which the GraphQL API should be served.
+   *
+   * @default
+   * /graphql
+   */
+  path?: string
+  /**
+   * Create a message suitable for printing to the terminal about the server
+   * having been booted.
+   */
+  startMessage?: (address: {
+    port: number
+    host: string
+    ip: string
+    path: string
+    playgroundPath?: string
+  }) => void
+}
+
+export type SettingsData = Omit<DeepRequired<SettingsInput>, 'host' | 'playground'> & {
+  host: string | undefined
+  playground: false | Required<PlaygroundSettings>
+}
+
+export const defaultPlaygroundPath = '/'
+export const defaultPlaygroundSettings: Readonly<Required<PlaygroundSettings>> = Object.freeze({
+  path: defaultPlaygroundPath,
+})
+
+/**
+ * The default server options. These are merged with whatever you provide. Your
+ * settings take precedence over these.
+ */
+export const defaultSettings: Readonly<SettingsData> = Object.freeze({
+  host: process.env.NEXUS_HOST ?? process.env.HOST ?? undefined,
+  port:
+    typeof process.env.NEXUS_PORT === 'string'
+      ? parseInt(process.env.NEXUS_PORT, 10)
+      : typeof process.env.PORT === 'string'
+      ? // e.g. Heroku convention https://stackoverflow.com/questions/28706180/setting-the-port-for-node-js-server-on-heroku
+        parseInt(process.env.PORT, 10)
+      : process.env.NODE_ENV === 'production'
+      ? 80
+      : 4000,
+  startMessage: ({ port, host, path, playgroundPath }): void => {
+    log.info('listening', { url: `http://${prettifyHost(host)}:${port}${playgroundPath ?? path}` })
+  },
+  playground: process.env.NODE_ENV === 'production' ? false : defaultPlaygroundSettings,
+  path: '/graphql',
+})
+
+/**
+ * Render IPv6 `::` as localhost. By default Node servers will use :: if IPv6
+ * host is available otherwise IPv4 0.0.0.0. In local development it seems that
+ * rendering as localhost makes the most sense as to what the user expects.
+ * According to Node docs most operating systems that are supporting IPv6
+ * somehow bind `::` to `0.0.0.0` anyways.
+ */
+function prettifyHost(host: string): string {
+  return host === '::' ? 'localhost' : host
+}
+
+function playgroundPath(settings: true | PlaygroundSettings): string {
+  if (settings === true) {
+    return defaultPlaygroundPath
+  }
+
+  if (settings.path === undefined) {
+    return defaultPlaygroundPath
+  }
+
+  if (settings.path.length === 0) {
+    fatal('Custom playground `path` cannot be empty and must start with a "/"')
+  }
+
+  if (settings.path.startsWith('/') === false) {
+    log.warn('Custom playground `path` must start with a "/". Please add it.')
+
+    return '/' + settings.path
+  }
+
+  return settings.path
+}
+
+export function playgroundSettings(settings: SettingsInput['playground']): SettingsData['playground'] {
+  if (!settings) {
+    return false
+  }
+
+  return {
+    path: playgroundPath(settings),
+  }
+}
+
+function validateGraphQLPath(path: string): string {
+  let outputPath = path
+
+  if (path.length === 0) {
+    fatal('Custom GraphQL `path` cannot be empty and must start with a /')
+  }
+
+  if (path.startsWith('/') === false) {
+    log.warn('Custom GraphQL `path` must start with a "/". Please add it.')
+
+    outputPath = '/' + outputPath
+  }
+
+  return outputPath
+}
+
+export function changeSettings(oldSettings: SettingsData, newSettings: SettingsInput): SettingsData {
+  const outputSettings = { ...oldSettings, ...newSettings }
+  const playground = playgroundSettings(outputSettings.playground)
+
+  outputSettings.path = validateGraphQLPath(outputSettings.path)
+
+  return {
+    ...outputSettings,
+    playground,
+  }
+}

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -1,6 +1,8 @@
 import { DeepRequired } from 'utility-types'
 import { fatal } from '../../lib/process'
-import { log } from './logger'
+import { log as serverLogger } from './logger'
+
+const log = serverLogger.child('settings')
 
 export type PlaygroundSettings = {
   path?: string
@@ -76,7 +78,7 @@ export const defaultSettings: Readonly<SettingsData> = Object.freeze({
       ? 80
       : 4000,
   startMessage: ({ port, host, path, playgroundPath }): void => {
-    log.info('listening', { url: `http://${prettifyHost(host)}:${port}${playgroundPath ?? path}` })
+    serverLogger.info('listening', { url: `http://${prettifyHost(host)}:${port}${playgroundPath ?? path}` })
   },
   playground: process.env.NODE_ENV === 'production' ? false : defaultPlaygroundSettings,
   path: '/graphql',

--- a/src/runtime/start/dev-runner.ts
+++ b/src/runtime/start/dev-runner.ts
@@ -22,7 +22,7 @@ export interface DevRunner {
 export function createDevAppRunner(
   layout: Layout.Layout,
   opts?: {
-    server?: Server.ExtraSettingsInput
+    server?: Server.SettingsInput
     disableServer?: boolean
   }
 ): DevRunner {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,6 +5722,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+utility-types@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"


### PR DESCRIPTION
closes #683 

Went on a server settings refactor to better support more config in the future. It also streamlines how settings is managed in other components

#### TODO

- [x] docs
- [ ] tests
