### PR TITLE
fix: custom build output (`nexus build -o`)

### DIFF
--- a/src/lib/build/build.ts
+++ b/src/lib/build/build.ts
@@ -1,5 +1,6 @@
 import { stripIndent } from 'common-tags'
 import * as FS from 'fs-jetpack'
+import * as Path from 'path'
 import * as Layout from '../../lib/layout'
 import { compile, createTSProgram, deleteTSIncrementalFile } from '../../lib/tsc'
 import {
@@ -33,9 +34,10 @@ export async function buildNexusApp(settings: BuildSettings) {
 
   const startTime = Date.now()
   const deploymentTarget = normalizeTarget(settings.target)
+  const buildOutput = settings.output ?? computeBuildOutputFromTarget(deploymentTarget) ?? undefined
 
   const layout = await Layout.create({
-    buildOutputRelative: settings.output ?? computeBuildOutputFromTarget(deploymentTarget) ?? undefined,
+    buildOutput,
     entrypointPath: settings.entrypoint,
   })
 
@@ -70,9 +72,9 @@ export async function buildNexusApp(settings: BuildSettings) {
     startModule: prepareStartModule(
       tsBuilder,
       createStartModuleContent({
+        layout,
         plugins: manifests,
         internalStage: 'build',
-        layout: layout,
       })
     ),
   })
@@ -113,7 +115,7 @@ export async function buildNexusApp(settings: BuildSettings) {
   })
 
   log.info('success', {
-    buildOutput: layout.buildOutputRelative,
+    buildOutput: Path.relative(layout.projectRoot, layout.buildOutput),
     time: Date.now() - startTime,
   })
 

--- a/src/lib/build/deploy-target.ts
+++ b/src/lib/build/deploy-target.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
-import * as path from 'path'
 import * as Path from 'path'
 import { DEFAULT_BUILD_FOLDER_PATH_RELATIVE_TO_PROJECT_ROOT, Layout } from '../../lib/layout'
 import { START_MODULE_NAME } from '../../runtime/start/start-module'
@@ -97,7 +96,7 @@ function validateNow(layout: Layout): ValidatorResult {
         "routes": [{ "src": "/.*", "dest": "${startModulePath}" }]
       }
     `
-    const nowJsonPath = path.join(layout.projectRoot, 'now.json')
+    const nowJsonPath = Path.join(layout.projectRoot, 'now.json')
     fs.write(nowJsonPath, nowJsonContent)
     log.warn(`No \`now.json\` file were found. We scaffolded one for you in ${nowJsonPath}`)
   } else {
@@ -192,20 +191,22 @@ function validateHeroku(layout: Layout): ValidatorResult {
       isValid = false
     }
 
+    const relativeBuildOutput = Path.relative(layout.packageJson.dir, layout.buildOutput)
+
     // Make sure there's a start script
     if (!pcfg.scripts?.start) {
       log.error(
-        `Please add the following to your \`package.json\` file: "scripts": { "start": "node ${layout.buildOutput}" }`
+        `Please add the following to your \`package.json\` file: "scripts": { "start": "node ${relativeBuildOutput}" }`
       )
       console.log()
       isValid = false
     }
 
     // Make sure the start script starts the built server
-    if (!pcfg.scripts?.start?.includes(`node ${layout.buildOutput}`)) {
+    if (!pcfg.scripts?.start?.includes(`node ${relativeBuildOutput}`)) {
       log.error(`Please make sure your \`start\` script points to your built server`)
       log.error(`Found: "${pcfg.scripts?.start}"`)
-      log.error(`Expected: "node ${layout.buildOutput}"`)
+      log.error(`Expected to contain: "node ${relativeBuildOutput}"`)
       console.log()
       isValid = false
     }

--- a/src/lib/layout/tsconfig.ts
+++ b/src/lib/layout/tsconfig.ts
@@ -16,7 +16,7 @@ const diagnosticHost: ts.FormatDiagnosticsHost = {
 export async function readOrScaffoldTsconfig(input: {
   projectRoot: string
   overrides?: { outRoot?: string }
-}): Promise<ts.ParsedCommandLine> {
+}): Promise<{ content: ts.ParsedCommandLine, path: string }> {
   let tsconfigPath = ts.findConfigFile(input.projectRoot, ts.sys.fileExists, 'tsconfig.json')
 
   if (!tsconfigPath) {
@@ -103,7 +103,7 @@ export async function readOrScaffoldTsconfig(input: {
 
   log.trace('finished read')
 
-  return tsconfig
+  return { content: tsconfig, path: tsconfigPath }
 }
 
 function checkNoTsConfigErrors(tsconfig: ts.ParsedCommandLine) {

--- a/src/lib/tsc.ts
+++ b/src/lib/tsc.ts
@@ -29,7 +29,8 @@ export function createTSProgram(
     rootNames: layout.schemaModules.concat(layout.app.exists ? [layout.app.path] : []),
     options: {
       ...compilerCacheOptions,
-      ...layout.tsConfigJson.options,
+      ...layout.tsConfig.content.options,
+      outDir: layout.buildOutput,
     },
   })
 
@@ -79,7 +80,7 @@ export function compile(
 ): void {
   if (options?.removePreviousBuild === true) {
     log.trace('remove previous build folder if present')
-    fs.remove(layout.buildOutputRelative)
+    fs.remove(layout.buildOutput)
   }
 
   log.trace('emit transpiled modules')

--- a/src/runtime/start/start-module.ts
+++ b/src/runtime/start/start-module.ts
@@ -78,7 +78,7 @@ export function createStartModuleContent(config: StartModuleConfig): string {
       require('${
         config.absoluteModuleImports
           ? config.layout.packageJson.path
-          : Path.relative(config.layout.buildOutputRelative, config.layout.packageJson.path)
+          : Path.relative(config.layout.buildOutput, config.layout.packageJson.path)
       }')
     `
   }


### PR DESCRIPTION
## Description

- closes #685, 
- Refactor layout to normalize build output as absolute path
- Fix precedence of build output. User input > outDir > default
- Make ts use the right build output
- Fix heroku/now deployment validation
- Add tests


#### TODO

- [ ] docs
- [x] tests
