### PR TITLE
fix: build error because of utility-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "jest": "25.2.7",
     "node-pty": "0.9.0",
     "prettier": "2.0.4",
-    "ts-jest": "25.3.1",
-    "utility-types": "^3.10.0"
+    "ts-jest": "25.3.1"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/lib/plugin/types/lens.ts
+++ b/src/lib/plugin/types/lens.ts
@@ -1,6 +1,5 @@
 import * as NexusSchema from '@nexus/schema'
 import * as Prompts from 'prompts'
-import { DeepPartial } from 'utility-types'
 import * as Testing from '../../../runtime/testing'
 import * as Layout from '../../layout'
 import * as Logger from '../../logger'
@@ -134,7 +133,7 @@ export type RuntimeContributions<C extends {} = any> = {
   }
 }
 
-export type TesttimeContributions = DeepPartial<Testing.TestContextCore> & { [prop: string]: any }
+export type TesttimeContributions = Utils.DeepPartial<Testing.TestContextCore> & { [prop: string]: any }
 
 export type Lens = {
   log: Logger.Logger

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,7 +7,7 @@ export type SideEffector = () => MaybePromise
 export type Param1<F> = F extends (p: infer P, ...args: any[]) => any ? P : never
 
 /**
- * DeepPartial
+ * DeepPartial - borrowed from `utility-types`
  * @desc Partial that works for deeply nested structure
  * @example
  *   // Expect: {
@@ -41,7 +41,7 @@ export declare type DeepPartialObject<T> = {
 }
 
 /**
- * DeepRequired
+ * DeepRequired - borrowed from `utility-types`
  * @desc Required that works for deeply nested structure
  * @example
  *   // Expect: {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,6 +7,75 @@ export type SideEffector = () => MaybePromise
 export type Param1<F> = F extends (p: infer P, ...args: any[]) => any ? P : never
 
 /**
+ * DeepPartial
+ * @desc Partial that works for deeply nested structure
+ * @example
+ *   // Expect: {
+ *   //   first?: {
+ *   //     second?: {
+ *   //       name?: string;
+ *   //     };
+ *   //   };
+ *   // }
+ *   type NestedProps = {
+ *     first: {
+ *       second: {
+ *         name: string;
+ *       };
+ *     };
+ *   };
+ *   type PartialNestedProps = DeepPartial<NestedProps>;
+ */
+export declare type DeepPartial<T> = T extends Function
+  ? T
+  : T extends Array<infer U>
+  ? DeepPartialArray<U>
+  : T extends object
+  ? DeepPartialObject<T>
+  : T | undefined
+/** @private */
+export interface DeepPartialArray<T> extends Array<DeepPartial<T>> {}
+/** @private */
+export declare type DeepPartialObject<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>
+}
+
+/**
+ * DeepRequired
+ * @desc Required that works for deeply nested structure
+ * @example
+ *   // Expect: {
+ *   //   first: {
+ *   //     second: {
+ *   //       name: string;
+ *   //     };
+ *   //   };
+ *   // }
+ *   type NestedProps = {
+ *     first?: {
+ *       second?: {
+ *         name?: string;
+ *       };
+ *     };
+ *   };
+ *   type RequiredNestedProps = DeepRequired<NestedProps>;
+ */
+export declare type DeepRequired<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends any[]
+  ? DeepRequiredArray<T[number]>
+  : T extends object
+  ? DeepRequiredObject<T>
+  : T
+/** @private */
+export interface DeepRequiredArray<T> extends Array<DeepRequired<NonUndefined<T>>> {}
+/** @private */
+export declare type DeepRequiredObject<T> = {
+  [P in keyof T]-?: DeepRequired<NonUndefined<T[P]>>
+}
+export declare type NonUndefined<A> = A extends undefined ? never : A
+
+/**
  * Guarantee the length of a given string, padding before or after with the
  * given character. If the given string is longer than  the span target, then it
  * will be cropped.

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -1,4 +1,3 @@
-import * as UtilityTypes from 'utility-types'
 import * as Process from '../../lib/process'
 import * as Utils from '../../lib/utils'
 import { log as serverLogger } from './logger'
@@ -53,7 +52,7 @@ export type SettingsInput = {
   }) => void
 }
 
-export type SettingsData = Omit<UtilityTypes.DeepRequired<SettingsInput>, 'host' | 'playground'> & {
+export type SettingsData = Omit<Utils.DeepRequired<SettingsInput>, 'host' | 'playground'> & {
   host: string | undefined
   playground: false | Required<PlaygroundSettings>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,11 +5722,6 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-utility-types@^3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
-  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
-
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"


### PR DESCRIPTION
## Description

Because `utility-types` is used on the plugin interface (and thus the public api), it cannot be a dev dependencies.

Given that we only use two of its type, I decided to remove it so that it doesn't end up in the `dependencies`. I copy & pasted the two types instead (`DeepRequired` & `DeepPartial`)