### PR TITLE
fix:Windows bug fixes #538

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 - **Discussions** https://github.com/graphql-nexus/nexus/discussions
 - **Changelog** https://github.com/graphql-nexus/nexus/releases ([canary](https://github.com/graphql-nexus/nexus/releases/tag/next))
 
+## Windows users
+
+This framework uses node-gyp which on windows machines has additional requirements that must be installed manually before hand. Please refer to https://github.com/nodejs/node-gyp#on-windows.
+
 ## Repo / Package Overview
 
 | Repo                                              | NPM Package                                                  | Role             |

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -62,6 +62,7 @@ export function findFileRecurisvelyUpwardSync(
   let found: { path: string; dir: string } | null = null
   let currentDir = opts.cwd
   const localFS = FS.cwd(currentDir)
+  let second = path.win32.normalize('\\')
 
   while (true) {
     const filePath = Path.join(currentDir, fileName)
@@ -71,7 +72,7 @@ export function findFileRecurisvelyUpwardSync(
       break
     }
 
-    if (currentDir === '/') {
+    if (currentDir === '/' || currentDir.slice(2) === second) {
       break
     }
 

--- a/src/lib/logger/pino.ts
+++ b/src/lib/logger/pino.ts
@@ -33,21 +33,18 @@ type Options = {
  * Currently when changing in/out of pretty mode and construction time.
  */
 export function create(opts: Options): Pino.Logger {
-  const pino = originalCreatePino(
-    {
-      prettyPrint: opts.pretty.enabled,
-      prettifier: (_opts: any) =>
-        opts.pretty.color
-          ? Prettifier.create(opts.pretty)
-          : // todo more performant way to do this would be give task to de-colour
-            // to render function. Then it can just use some cheap if conditions.
-            // Presumably strip-ansi is doing WAY more work as it has to
-            // traverse EVERY string logged...
-            Lo.flow(Prettifier.create(opts.pretty), stripAnsi),
-      messageKey: 'event',
-    } as ActualPinoOptions,
-    opts.output
-  )
+  const pino = originalCreatePino({
+    prettyPrint: opts.pretty.enabled,
+    prettifier: (_opts: any) =>
+      opts.pretty.color
+        ? Prettifier.create(opts.pretty)
+        : // todo more performant way to do this would be give task to de-colour
+          // to render function. Then it can just use some cheap if conditions.
+          // Presumably strip-ansi is doing WAY more work as it has to
+          // traverse EVERY string logged...
+          Lo.flow(Prettifier.create(opts.pretty), stripAnsi),
+    messageKey: 'event',
+  } as ActualPinoOptions)
   pino.level = opts.level
   return pino
 }


### PR DESCRIPTION
This changes were made in order to get Nexus running on Windows machines per #538 

Updated Readme.md with instructions and link for Windows users to manually install prerequisite dependencies for node-gyp, a dependency of nexus.

Both of the following 2 issues were causing nexus to throw errors and crash on Windows machines:

src\lib\fs.ts - Updated logic in the findFileRecurisvelyUpwardSync function so it can correctly break out of the loop when the root is on a windows machine.

src\lib\logger\pino.ts - removed second argument (opts.output) from being fed into the originalCreatePino function which only takes one argument. May have been left over from debugging?

TODO: While the cli is now creating the first new files and prompting the user for input on package manager and database choice, it still errors out once it prints 'Scaffolding Project' to the log (src/cli/commands/create/app.ts line 90) due to the program pulling the nexus version to install from the local package (0.0.0-dripip) and trying to install it using the user chosen package manager. However, '0.0.0-dripiop' is not a version of nexus available to be installed. Logic in the getNexusVersion function may need to be updated? (src/cli/commands/create/apps.ts line 199). Please provide guidance. 
