### PR TITLE
chore(website): fix mismatch between db/gql schemas in tutorial

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -53,7 +53,7 @@ We're going to need to expose the `moons` world field to clients
   schema.objectType({
     name: "World",
     definition(t) {
-      t.model.id()
+      t.model.worldId()
       t.model.name()
       t.model.population()
 +     t.model.moons()


### PR DESCRIPTION
closes #706 

Just a small fix in the getting started tutorial. There was a name mismatch between a column in the DB schema and the GraphQL schema.

Side note: really excited about the deep focus on user experience by nexusjs.

cc @jasonkuhrt

#### TODO

- ~~[ ] docs~~
- ~~[ ] tests~~
