### PR TITLE
chore(website): fix enum example mismatch

### DIFF
--- a/docs/plugins/prisma.md
+++ b/docs/plugins/prisma.md
@@ -850,7 +850,7 @@ enum Mood {
 }
 
 enum Role {
-  AUTHOR
+  MEMBER
   EDITOR
 }
 


### PR DESCRIPTION
The roles are defined as

```ts
enumType({
  name: 'Role',
  members: ['MEMBER', 'EDITOR'],
})
```

but the "output" is 

```gql
enum Role {
  AUTHOR
  EDITOR
}
```

This fixes the wrong output role