### PR TITLE
feat(server): add customErrorFormatter configuration

### DIFF
--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -74,7 +74,7 @@ function setupExpress(express: Express, settings: SetupExpressInput): BaseServer
 
           error.message = colorlessMessage
 
-          return error
+          return settings.customErrorFormatter ? settings.customErrorFormatter(error) : error
         },
       }))
     })

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -50,11 +50,20 @@ export type SettingsInput = {
     path: string
     playgroundPath?: string
   }) => void
+  /**
+   * An optional function which will be used to format any errors produced by
+   * fulfilling a GraphQL operation.
+   */
+  customErrorFormatter?: (error: Error) => unknown | null
 }
 
-export type SettingsData = Omit<Utils.DeepRequired<SettingsInput>, 'host' | 'playground'> & {
+export type SettingsData = Omit<
+  Utils.DeepRequired<SettingsInput>,
+  'host' | 'playground' | 'customErrorFormatter'
+> & {
   host: string | undefined
   playground: false | Required<PlaygroundSettings>
+  customErrorFormatter?: (error: Error) => unknown | null
 }
 
 export const defaultPlaygroundPath = '/'


### PR DESCRIPTION
Simply expose a customErrorFormatter function to handle and extends errors.

I'm aware this may be too low level for nexus (see #241).
Tell me if i can help on this topic.
