### PR TITLE
feat(schema): extract union type refs in addToContext

### DIFF
--- a/src/lib/add-to-context-extractor/extractor.spec.ts
+++ b/src/lib/add-to-context-extractor/extractor.spec.ts
@@ -277,6 +277,61 @@ it('prop type aliased intersection', () => {
   `)
 })
 
+it('prop type union', () => {
+  expect(
+    extract(`
+        export type Bar = { b: 2 }
+        export type Foo = { a: 1 }
+        schema.addToContext(req => { return { foo: '' as any as Foo | Bar } })
+      `)
+  ).toMatchInlineSnapshot(`
+    Object {
+      "typeImports": Array [
+        Object {
+          "isExported": true,
+          "isNode": false,
+          "modulePath": "/src/a",
+          "name": "Foo",
+        },
+        Object {
+          "isExported": true,
+          "isNode": false,
+          "modulePath": "/src/a",
+          "name": "Bar",
+        },
+      ],
+      "types": Array [
+        "{ foo: Foo | Bar; }",
+      ],
+    }
+  `)
+})
+
+it('prop type aliased union', () => {
+  expect(
+    extract(`
+        type Bar = { b: 2 }
+        type Foo = { a: 1 }
+        export type Qux = Foo | Bar
+        schema.addToContext(req => { return { foo: '' as any as Qux } })
+      `)
+  ).toMatchInlineSnapshot(`
+    Object {
+      "typeImports": Array [
+        Object {
+          "isExported": true,
+          "isNode": false,
+          "modulePath": "/src/a",
+          "name": "Qux",
+        },
+      ],
+      "types": Array [
+        "{ foo: Qux; }",
+      ],
+    }
+  `)
+})
+
 // todo Feature is supported, but untested.
 // todo how do we test this?
 it.todo('truncates import paths when detected to be a node stdlib module')

--- a/src/lib/add-to-context-extractor/extractor.ts
+++ b/src/lib/add-to-context-extractor/extractor.ts
@@ -149,9 +149,7 @@ export function extractContextTypes(program: ts.Program): ExtractedContextTypes 
               }
             } else if (t.isUnion()) {
               log.trace('found union', {
-                types: t
-                  .getIntersectionTypes()
-                  .map((t) => t.getText(undefined, ts.TypeFormatFlags.NoTruncation)),
+                types: t.getUnionTypes().map((t) => t.getText(undefined, ts.TypeFormatFlags.NoTruncation)),
               })
               const infos = t
                 .getUnionTypes()

--- a/src/lib/add-to-context-extractor/extractor.ts
+++ b/src/lib/add-to-context-extractor/extractor.ts
@@ -147,6 +147,21 @@ export function extractContextTypes(program: ts.Program): ExtractedContextTypes 
                   typeImportsIndex[info.name] = info
                 })
               }
+            } else if (t.isUnion()) {
+              log.trace('found union', {
+                types: t
+                  .getIntersectionTypes()
+                  .map((t) => t.getText(undefined, ts.TypeFormatFlags.NoTruncation)),
+              })
+              const infos = t
+                .getUnionTypes()
+                .map((t) => extractTypeImportInfoFromType(t)!)
+                .filter((info) => info !== null)
+              if (infos.length) {
+                infos.forEach((info) => {
+                  typeImportsIndex[info.name] = info
+                })
+              }
             } else {
               const info = extractTypeImportInfoFromType(t)
               if (info) {


### PR DESCRIPTION
Add missing union type extraction when generating context types.
relates #440 

#### TODO

- [ ] docs
- [x] tests
