### PR TITLE
chore(website): Remove extra ] from link url

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ We plan to lift these limitations one day.
 - Does not work with JavaScript [#85](https://github.com/graphql-nexus/nexus/issues/85)
 - Does not cover the entire GrpahQL Spec
   - Subscriptions [#447](https://github.com/graphql-nexus/nexus/issues/447)
-  - Interface Extensions [#713](https://github.com/graphql-nexus/nexus/issues/713])
+  - Interface Extensions [#713](https://github.com/graphql-nexus/nexus/issues/713)
 
 ### Non-Goals
 


### PR DESCRIPTION
Removed a trailing `]` character from one of the readme links.

#### TODO

- [X] **Docs:** Docs were updated to fix a bad link.
- [X] **Tests:** No tests were added as part of this PR since it's just a documentation change.
