### PR TITLE
feat: app assembly

### DIFF
--- a/docs/api/modules/main/exports/server.md
+++ b/docs/api/modules/main/exports/server.md
@@ -4,22 +4,6 @@
 
 Use the server to run the HTTP server that clients will connect to.
 
-### `start`
-
-Make the server start listening for incoming client connections.
-
-Calling start while already started is a no-op.
-
-Normally you should not need to use this method. When your app does not call `server.start`, Nexus will do so for you automatically.
-
-### `stop`
-
-Make the server stop listening for incoming client connections.
-
-Calling stop while the server is already stopped is a no-op.
-
-Normally you should not need to use this method.
-
 ### `express`
 
 Gives you access to the underlying `express` instance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,11 @@
+## Reflection
+
+todo
+
+## Assembly
+
+todo
+
 ## Build Flow
 
 1. The app layout is calculated  
@@ -37,3 +45,21 @@ what follows is a stub
    1. validate imported value
    1. load plugin
    1. catch any load errors
+
+## Glossary
+
+### Assembly
+
+The process in which the app configuration (settings, schema type defs, used plugins, etc.) is processed into a runnable state. Nexus apps are only ever assembled once in their lifecycle.
+
+### Dynamic Reflection
+
+The process in which the app is run in order to extract data out of it. The data in turn can be used for anything. For example typegen to provide better TypeScript types or GraphQL SDL generation.
+
+### Static Reflection
+
+The process in which the app is analyzed with the TS API to extract data out of it. The data in turn can be used for anything. For example typegen to provide better TypeScript types.
+
+### Reflection
+
+The general idea of the app source code or its state at runtime being analyzed to extract data.

--- a/src/lib/reflection/stage.ts
+++ b/src/lib/reflection/stage.ts
@@ -17,3 +17,10 @@ export function saveReflectionStageEnv(type: ReflectionType) {
 export function isReflectionStage(type: ReflectionType) {
   return process.env[REFLECTION_ENV_VAR] === type
 }
+
+/**
+ * Check whether the app is executing in its reflection stage
+ */
+export function isReflection() {
+  return process.env[REFLECTION_ENV_VAR] !== undefined
+}

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -124,14 +124,14 @@ export function create(): App {
       serverComponent.private.assemble(loadedRuntimePlugins, appState.schemaComponent.schema!)
     },
     async start() {
+      if (Reflection.isReflection()) return
       if (appState.running) return
       await serverComponent.private.start()
       appState.running = true
     },
     async stop() {
+      if (Reflection.isReflection()) return
       if (!appState.running) return
-      // todo should components hook onto an app event, "onStop"?
-      // todo should app state be reset?
       await serverComponent.private.stop()
       appState.running = false
     },

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,11 +1,10 @@
 import * as Logger from '@nexus/logger'
 import { stripIndent } from 'common-tags'
-import * as Lo from 'lodash'
 import * as Plugin from '../lib/plugin'
+import * as Reflection from '../lib/reflection'
 import * as Schema from './schema'
 import * as Server from './server'
-import * as NexusSchema from '@nexus/schema'
-import * as Reflection from '../lib/reflection'
+import * as Settings from './settings'
 
 const log = Logger.create({ name: 'app' })
 
@@ -27,168 +26,126 @@ export interface App {
   /**
    * todo
    */
-  settings: Settings
+  settings: Settings.Settings
   /**
    * [API Reference](https://www.nexusjs.org/#/api/modules/main/exports/schema) // [Guide](todo)
    *
    * ### todo
    */
   schema: Schema.Schema
-
+  /**
+   * todo
+   */
   use(plugin: Plugin.Plugin): void
-}
-
-type SettingsInput = {
-  logger?: Logger.SettingsInput
-  schema?: Schema.SettingsInput
-  server?: Server.SettingsInput
-}
-
-export type SettingsData = Readonly<{
-  logger: Logger.SettingsData
-  schema: Schema.SettingsData
-  server: Server.SettingsData
-}>
-
-/**
- * todo
- */
-export type Settings = {
   /**
    * todo
    */
-  original: SettingsData
+  assemble(): any
   /**
    * todo
    */
-  current: SettingsData
+  start(): any
   /**
    * todo
    */
-  change(newSetting: SettingsInput): void
+  stop(): any
+  /**
+   * todo
+   */
 }
 
 export type AppState = {
-  plugins: () => Plugin.Plugin[]
-  schema: () => NexusSchema.core.NexusGraphQLSchema
-  isWasServerStartCalled: boolean
+  plugins: Plugin.Plugin[]
+  // schema: () => NexusSchema.core.NexusGraphQLSchema
+  /**
+   * Once the app is started incremental component APIs can no longer be used. This
+   * flag let's those APIs detect that they are being used after app start. Then
+   * they can do something useful like tell the user about their mistake.
+   */
+  assembled: boolean
+  running: boolean
+  schemaComponent: Schema.LazyState
 }
 
-export type InternalApp = App & {
-  __state: AppState
+export type PrivateApp = App & {
+  private: {
+    state: AppState
+  }
 }
 
 /**
- * Crate an app instance
+ * Create new app state. Be careful to pass this state to components to complete its
+ * data. The data returned only contains core state, despite what the return
+ * type says.
+ */
+export function createAppState(): AppState {
+  const appState = {
+    assembled: false,
+    running: false,
+    plugins: [],
+  } as Omit<AppState, 'schemaComponent'>
+
+  return appState as any
+}
+
+/**
+ * Create an app instance
  */
 export function create(): App {
-  let _plugins: Plugin.Plugin[] = []
-  let _schema: NexusSchema.core.NexusGraphQLSchema | null = null
-
-  const __state: InternalApp['__state'] = {
-    plugins() {
-      return _plugins
-    },
-    schema() {
-      if (_schema === null) {
-        throw new Error('GraphQL schema was not built yet. server.start() needs to be run first')
-      }
-
-      return _schema
-    },
-    isWasServerStartCalled: false,
-  }
-
-  const server = Server.create()
-  const schemaComponent = Schema.create(__state)
-
-  const settings: Settings = {
-    change(newSettings) {
-      if (newSettings.logger) {
-        log.settings(newSettings.logger)
-      }
-      if (newSettings.schema) {
-        schemaComponent.private.settings.change(newSettings.schema)
-      }
-      if (newSettings.server) {
-        server.settings.change(newSettings.server)
-      }
-    },
-    current: {
-      logger: log.settings,
-      schema: schemaComponent.private.settings.data,
-      server: server.settings.data,
-    },
-    original: Lo.cloneDeep({
-      logger: log.settings,
-      schema: schemaComponent.private.settings.data,
-      server: server.settings.data,
-    }),
-  }
-
-  const api: InternalApp = {
-    __state,
+  const appState = createAppState()
+  const serverComponent = Server.create(appState)
+  const schemaComponent = Schema.create(appState)
+  const settingsComponent = Settings.create({
+    serverSettings: serverComponent.private.settings,
+    schemaSettings: schemaComponent.private.settings,
+    log,
+  })
+  const api: PrivateApp = {
     log: log,
-    settings: settings,
+    settings: settingsComponent.public,
     schema: schemaComponent.public,
+    server: serverComponent.public,
+    // todo call this in the start module
+    assemble() {
+      if (appState.assembled) return
+
+      appState.assembled = true
+
+      if (Reflection.isReflectionStage('plugin')) return
+
+      const loadedRuntimePlugins = Plugin.importAndLoadRuntimePlugins(appState.plugins)
+
+      schemaComponent.private.assemble(loadedRuntimePlugins)
+
+      if (Reflection.isReflectionStage('typegen')) return
+
+      schemaComponent.private.checks()
+
+      serverComponent.private.assemble(loadedRuntimePlugins, appState.schemaComponent.schema!)
+    },
+    async start() {
+      if (appState.running) return
+      await serverComponent.private.start()
+      appState.running = true
+    },
+    async stop() {
+      if (!appState.running) return
+      // todo should components hook onto an app event, "onStop"?
+      // todo should app state be reset?
+      await serverComponent.private.stop()
+      appState.running = false
+    },
     use(plugin) {
-      if (__state.isWasServerStartCalled === true) {
+      if (appState.assembled === true) {
         log.warn(stripIndent`
           A plugin was ignored because it was loaded after the server was started
           Make sure to call \`use\` before you call \`server.start\`
         `)
       }
-
-      _plugins.push(plugin)
+      appState.plugins.push(plugin)
     },
-    server: {
-      express: server.express,
-      /**
-       * Start the server. If you do not call this explicitly then nexus will
-       * for you. You should not normally need to call this function yourself.
-       */
-      async start() {
-        // Track the start call so that we can know in entrypoint whether to run
-        // or not start for the user.
-        __state.isWasServerStartCalled = true
-
-        /**
-         * If loading plugins, we need to return here, before loading the runtime plugins
-         */
-         if (Reflection.isReflectionStage('plugin')) {
-           return Promise.resolve()
-         }
-
-        const plugins = Plugin.importAndLoadRuntimePlugins(__state.plugins())
-        const { schema, assertValidSchema } = schemaComponent.private.makeSchema(plugins)
-
-        /**
-         * Set the schema in the app state so that the reflection step can access it
-         */
-        _schema = schema
-
-        /**
-         * If execution in in reflection stage, do not run the server
-         */
-        if (Reflection.isReflectionStage('typegen')) {
-          return Promise.resolve()
-        }
-
-        /**
-         * This needs to be done **after** the reflection step,
-         * to make sure typegen can still run in case of missing types
-         */
-        assertValidSchema()
-
-        await server.setupAndStart({
-          schema,
-          plugins,
-          contextContributors: schemaComponent.private.state.contextContributors,
-        })
-      },
-      stop() {
-        return server.stop()
-      },
+    private: {
+      state: appState,
     },
   }
 

--- a/src/runtime/schema/index.spec.ts
+++ b/src/runtime/schema/index.spec.ts
@@ -1,12 +1,14 @@
 import { plugin } from '@nexus/schema'
-import { create } from './schema'
+import { AppState, createAppState } from '../app'
+import { create, SchemaInternal } from './schema'
 import { mapSettingsToNexusSchemaConfig } from './settings'
 
-let schema: ReturnType<typeof create>
+let schema: SchemaInternal
+let appState: AppState
 
-// TODO: Figure out how to deal with `schema` and `plugins`
 beforeEach(() => {
-  schema = create({ isWasServerStartCalled: false, plugins: () => [], schema: () => null as any })
+  appState = createAppState()
+  schema = create(appState)
 })
 
 it('defaults to outputs being nullable by default', () => {
@@ -39,6 +41,6 @@ describe('use', () => {
   it('incrementally adds plugins', () => {
     schema.public.use(plugin({ name: 'foo' }))
     schema.public.use(plugin({ name: 'bar' }))
-    expect(schema.private.state.schemaPlugins.length).toEqual(2)
+    expect(appState.schemaComponent.plugins.length).toEqual(2)
   })
 })

--- a/src/runtime/schema/index.ts
+++ b/src/runtime/schema/index.ts
@@ -1,2 +1,2 @@
-export { create, Schema } from './schema'
+export { create, LazyState, Schema } from './schema'
 export { SettingsData, SettingsInput } from './settings'

--- a/src/runtime/schema/settings.ts
+++ b/src/runtime/schema/settings.ts
@@ -171,3 +171,21 @@ function defaultConnectionPlugin(configBase: ConnectionConfig): NexusSchema.core
     nexusFieldName: 'connection',
   })
 }
+
+function defaultSettings(): SettingsInput {
+  return {}
+}
+
+export function createSchemaSettingsManager() {
+  const data = defaultSettings()
+  const change = (newSettings: SettingsInput) => {
+    return changeSettings(data, newSettings)
+  }
+
+  return {
+    change,
+    data,
+  }
+}
+
+export type SchemaSettingsManager = ReturnType<typeof createSchemaSettingsManager>

--- a/src/runtime/server/handle.ts
+++ b/src/runtime/server/handle.ts
@@ -1,0 +1,48 @@
+import { execute, GraphQLSchema, parse, Source, validate } from 'graphql'
+
+interface NexusRequest {
+  // todo currently assumes request body has been parsed as JSON
+  body: Record<string, string>
+}
+
+function createGraphQLRequestHandler(schema: GraphQLSchema) {
+  function handle(req: NexusRequest) {
+    const data = req.body
+    const source = new Source(data.query)
+
+    let documentAST
+    try {
+      documentAST = parse(source)
+    } catch (syntaxError) {
+      // todo
+      // https://github.com/graphql/express-graphql/blob/master/src/index.js
+      return
+    }
+
+    const validationFailures = validate(schema, documentAST)
+
+    if (validationFailures.length > 1) {
+      // todo
+      return
+    }
+
+    // todo validate that if operation is mutation or subscription then http method is not GET
+    // https://github.com/graphql/express-graphql/blob/master/src/index.js#L296
+
+    let result
+    try {
+      result = execute({
+        schema: schema,
+        document: documentAST,
+        // todo other options
+      })
+    } catch (error) {
+      // todo
+      return
+    }
+  }
+
+  return {
+    handle,
+  }
+}

--- a/src/runtime/server/request-handler-playground.ts
+++ b/src/runtime/server/request-handler-playground.ts
@@ -1,0 +1,70 @@
+import { RequestHandler } from 'express'
+
+type Settings = {
+  graphqlEndpoint: string
+}
+
+type Handler = (settings: Settings) => RequestHandler
+
+export const createRequestHandlerPlayground: Handler = (settings) => (_req, res) => {
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+
+    <head>
+      <meta charset=utf-8/>
+      <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+      <title>GraphQL Playground</title>
+      <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+      <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+      <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+    </head>
+
+    <body>
+      <div id="root">
+        <style>
+          body {
+            background-color: rgb(23, 42, 58);
+            font-family: Open Sans, sans-serif;
+            height: 90vh;
+          }
+
+          #root {
+            height: 100%;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+          }
+
+          .loading {
+            font-size: 32px;
+            font-weight: 200;
+            color: rgba(255, 255, 255, .6);
+            margin-left: 20px;
+          }
+
+          img {
+            width: 78px;
+            height: 78px;
+          }
+
+          .title {
+            font-weight: 400;
+          }
+        </style>
+        <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+        <div class="loading"> Loading
+          <span class="title">GraphQL Playground</span>
+        </div>
+      </div>
+      <script>window.addEventListener('load', function (event) {
+          GraphQLPlayground.init(document.getElementById('root'), {
+            endpoint: '${settings.graphqlEndpoint}'
+          })
+        })</script>
+    </body>
+
+    </html>
+  `)
+}

--- a/src/runtime/server/server-old.ts
+++ b/src/runtime/server/server-old.ts
@@ -1,0 +1,272 @@
+import * as Logger from '@nexus/logger'
+import createExpress, { Express } from 'express'
+import * as ExpressGraphQL from 'express-graphql'
+import * as GraphQL from 'graphql'
+import * as HTTP from 'http'
+import * as Net from 'net'
+import stripAnsi from 'strip-ansi'
+import * as Plugin from '../../lib/plugin'
+import * as Utils from '../../lib/utils'
+import * as DevMode from '../dev-mode'
+import { log } from './logger'
+import * as ServerSettings from './settings'
+
+// Avoid forcing users to use esModuleInterop
+const createExpressGraphql = ExpressGraphQL.default
+const resolverLogger = log.child('graphql')
+
+type Request = HTTP.IncomingMessage & { log: Logger.Logger }
+type ContextContributor<T extends {}> = (req: Request) => Utils.MaybePromise<T>
+
+export type ExpressInstance = Omit<Express, 'listen'>
+
+export interface BaseServer {
+  /**
+   * Start the server instance
+   */
+  start(): Promise<void>
+  /**
+   * Stop the server instance
+   */
+  stop(): Promise<void>
+}
+
+/**
+ * [API Reference](https://www.nexusjs.org/#/api/modules/main/exports/server)  ⌁  [Guide](todo)
+ *
+ * ### todo
+ *
+ */
+export interface Server extends BaseServer {
+  /**
+   * Gives access to the underlying express instance
+   * Do not use `express.listen` but `server.start` instead
+   */
+  express: ExpressInstance
+}
+
+export type SetupExpressInput = ExpressGraphQL.OptionsData &
+  ServerSettings.SettingsData & {
+    context: ContextCreator
+  }
+
+function setupExpress(express: Express, settings: SetupExpressInput): BaseServer {
+  const http = HTTP.createServer()
+
+  http.on('request', express)
+
+  express.use(
+    settings.path,
+    createExpressGraphql((req) => {
+      return settings.context(req).then((resolvedCtx) => ({
+        ...settings,
+        context: resolvedCtx,
+        customFormatErrorFn: (error: Error) => {
+          const colorlessMessage = stripAnsi(error.message)
+
+          if (process.env.NEXUS_STAGE === 'dev') {
+            resolverLogger.error(error.stack ?? error.message)
+          } else {
+            resolverLogger.error('An exception occured in one of your resolver', {
+              error: error.stack ? stripAnsi(error.stack) : colorlessMessage,
+            })
+          }
+
+          error.message = colorlessMessage
+
+          return error
+        },
+      }))
+    })
+  )
+  if (settings.playground) {
+    express.get(settings.playground.path, (_req, res) => {
+      res.send(`
+        <!DOCTYPE html>
+        <html>
+
+        <head>
+          <meta charset=utf-8/>
+          <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+          <title>GraphQL Playground</title>
+          <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+          <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+          <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+        </head>
+
+        <body>
+          <div id="root">
+            <style>
+              body {
+                background-color: rgb(23, 42, 58);
+                font-family: Open Sans, sans-serif;
+                height: 90vh;
+              }
+
+              #root {
+                height: 100%;
+                width: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+              }
+
+              .loading {
+                font-size: 32px;
+                font-weight: 200;
+                color: rgba(255, 255, 255, .6);
+                margin-left: 20px;
+              }
+
+              img {
+                width: 78px;
+                height: 78px;
+              }
+
+              .title {
+                font-weight: 400;
+              }
+            </style>
+            <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+            <div class="loading"> Loading
+              <span class="title">GraphQL Playground</span>
+            </div>
+          </div>
+          <script>window.addEventListener('load', function (event) {
+              GraphQLPlayground.init(document.getElementById('root'), {
+                endpoint: '${settings.path}'
+              })
+            })</script>
+        </body>
+
+        </html>
+      `)
+    })
+  }
+
+  return {
+    start: () =>
+      new Promise<void>((res) => {
+        http.listen({ port: settings.port, host: settings.host }, () => {
+          // - We do not support listening on unix domain sockets so string
+          //   value will never be present here.
+          // - We are working within the listen callback so address will not be null
+          const address = http.address()! as Net.AddressInfo
+          settings.startMessage({
+            port: address.port,
+            host: address.address,
+            ip: address.address,
+            path: settings.path,
+            playgroundPath: settings.playground ? settings.playground.path : undefined,
+          })
+          res()
+        })
+      }),
+    stop: () =>
+      new Promise<void>((res, rej) => {
+        http.close((err) => {
+          if (err) {
+            rej(err)
+          } else {
+            res()
+          }
+        })
+      }),
+  }
+}
+
+interface ServerFactory {
+  setupAndStart(opts: {
+    schema: GraphQL.GraphQLSchema
+    plugins: Plugin.RuntimeContributions[]
+    contextContributors: ContextContributor<any>[]
+  }): Promise<void>
+  stop(): Promise<void>
+  express: ExpressInstance
+  settings: {
+    change(settings: ServerSettings.SettingsInput): void
+    data: ServerSettings.SettingsData
+  }
+}
+
+export function create(): ServerFactory {
+  const express = createExpress()
+  let server: BaseServer | null = null
+  const state = {
+    settings: ServerSettings.defaultSettings(),
+  }
+
+  return {
+    express,
+    async setupAndStart(opts: {
+      schema: GraphQL.GraphQLSchema
+      plugins: Plugin.RuntimeContributions[]
+      contextContributors: ContextContributor<any>[]
+    }) {
+      const context = contextFactory(opts.contextContributors, opts.plugins)
+
+      server = setupExpress(express, {
+        ...state.settings,
+        schema: opts.schema,
+        context,
+      })
+
+      await server.start()
+
+      DevMode.sendServerReadySignalToDevModeMaster()
+    },
+    stop() {
+      if (!server) {
+        log.warn('You called `server.stop` before calling `server.start`')
+        return Promise.resolve()
+      }
+
+      return server.stop()
+    },
+    settings: {
+      change(newSettings) {
+        state.settings = ServerSettings.changeSettings(state.settings, newSettings)
+      },
+      data: state.settings,
+    },
+  }
+}
+
+type AnonymousRequest = Record<string, any>
+type AnonymousContext = Record<string, any>
+
+type ContextCreator<
+  Req extends AnonymousRequest = AnonymousRequest,
+  Context extends AnonymousContext = AnonymousContext
+> = (req: Req) => Promise<Context>
+
+function contextFactory(
+  contextContributors: ContextContributor<any>[],
+  plugins: Plugin.RuntimeContributions[]
+): ContextCreator {
+  const createContext: ContextCreator = async (req) => {
+    let context: Record<string, any> = {}
+
+    // Integrate context from plugins
+    for (const plugin of plugins) {
+      if (!plugin.context) continue
+      const contextContribution = await plugin.context.create(req)
+
+      Object.assign(context, contextContribution)
+    }
+
+    // Integrate context from app context api
+    // TODO good runtime feedback to user if something goes wrong
+    for (const contextContributor of contextContributors) {
+      const contextContribution = await contextContributor((req as unknown) as Request)
+
+      Object.assign(context, contextContribution)
+    }
+
+    Object.assign(context, { log: log.child('request') })
+
+    return context
+  }
+
+  return createContext
+}

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -1,238 +1,111 @@
-import * as Logger from '@nexus/logger'
 import createExpress, { Express } from 'express'
 import * as ExpressGraphQL from 'express-graphql'
-import * as GraphQL from 'graphql'
+import { GraphQLSchema } from 'graphql'
 import * as HTTP from 'http'
 import * as Net from 'net'
 import stripAnsi from 'strip-ansi'
 import * as Plugin from '../../lib/plugin'
-import * as Utils from '../../lib/utils'
-import * as DevMode from '../dev-mode'
+import { AppState } from '../app'
+import { ContextContributor } from '../schema/schema'
 import { log } from './logger'
-import * as ServerSettings from './settings'
+import { createRequestHandlerPlayground } from './request-handler-playground'
+import { createServerSettingsManager } from './settings'
 
 // Avoid forcing users to use esModuleInterop
 const createExpressGraphql = ExpressGraphQL.default
-const resolverLogger = log.child('graphql')
 
-type Request = HTTP.IncomingMessage & { log: Logger.Logger }
-type ContextContributor<T extends {}> = (req: Request) => Utils.MaybePromise<T>
-
-export type ExpressInstance = Omit<Express, 'listen'>
-
-export interface BaseServer {
-  /**
-   * Start the server instance
-   */
-  start(): Promise<void>
-  /**
-   * Stop the server instance
-   */
-  stop(): Promise<void>
+export interface Server {
+  express: Express
 }
 
-/**
- * [API Reference](https://www.nexusjs.org/#/api/modules/main/exports/server)  ⌁  [Guide](todo)
- *
- * ### todo
- *
- */
-export interface Server extends BaseServer {
-  /**
-   * Gives access to the underlying express instance
-   * Do not use `express.listen` but `server.start` instead
-   */
-  express: ExpressInstance
-}
-
-export type SetupExpressInput = ExpressGraphQL.OptionsData &
-  ServerSettings.SettingsData & {
-    context: ContextCreator
-  }
-
-function setupExpress(express: Express, settings: SetupExpressInput): BaseServer {
-  const http = HTTP.createServer()
-
-  http.on('request', express)
-
-  express.use(
-    settings.path,
-    createExpressGraphql((req) => {
-      return settings.context(req).then((resolvedCtx) => ({
-        ...settings,
-        context: resolvedCtx,
-        customFormatErrorFn: (error: Error) => {
-          const colorlessMessage = stripAnsi(error.message)
-
-          if (process.env.NEXUS_STAGE === 'dev') {
-            resolverLogger.error(error.stack ?? error.message)
-          } else {
-            resolverLogger.error('An exception occured in one of your resolver', {
-              error: error.stack ? stripAnsi(error.stack) : colorlessMessage,
-            })
-          }
-
-          error.message = colorlessMessage
-
-          return error
-        },
-      }))
-    })
-  )
-  if (settings.playground) {
-    express.get(settings.playground.path, (_req, res) => {
-      res.send(`
-        <!DOCTYPE html>
-        <html>
-
-        <head>
-          <meta charset=utf-8/>
-          <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
-          <title>GraphQL Playground</title>
-          <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-          <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-          <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
-        </head>
-
-        <body>
-          <div id="root">
-            <style>
-              body {
-                background-color: rgb(23, 42, 58);
-                font-family: Open Sans, sans-serif;
-                height: 90vh;
-              }
-
-              #root {
-                height: 100%;
-                width: 100%;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-              }
-
-              .loading {
-                font-size: 32px;
-                font-weight: 200;
-                color: rgba(255, 255, 255, .6);
-                margin-left: 20px;
-              }
-
-              img {
-                width: 78px;
-                height: 78px;
-              }
-
-              .title {
-                font-weight: 400;
-              }
-            </style>
-            <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
-            <div class="loading"> Loading
-              <span class="title">GraphQL Playground</span>
-            </div>
-          </div>
-          <script>window.addEventListener('load', function (event) {
-              GraphQLPlayground.init(document.getElementById('root'), {
-                endpoint: '${settings.path}'
-              })
-            })</script>
-        </body>
-
-        </html>
-      `)
-    })
-  }
-
-  return {
-    start: () =>
-      new Promise<void>((res) => {
-        http.listen({ port: settings.port, host: settings.host }, () => {
-          // - We do not support listening on unix domain sockets so string
-          //   value will never be present here.
-          // - We are working within the listen callback so address will not be null
-          const address = http.address()! as Net.AddressInfo
-          settings.startMessage({
-            port: address.port,
-            host: address.address,
-            ip: address.address,
-            path: settings.path,
-            playgroundPath: settings.playground ? settings.playground.path : undefined,
-          })
-          res()
-        })
-      }),
-    stop: () =>
-      new Promise<void>((res, rej) => {
-        http.close((err) => {
-          if (err) {
-            rej(err)
-          } else {
-            res()
-          }
-        })
-      }),
-  }
-}
-
-interface ServerFactory {
-  setupAndStart(opts: {
-    schema: GraphQL.GraphQLSchema
-    plugins: Plugin.RuntimeContributions[]
-    contextContributors: ContextContributor<any>[]
-  }): Promise<void>
-  stop(): Promise<void>
-  express: ExpressInstance
-  settings: {
-    change(settings: ServerSettings.SettingsInput): void
-    data: ServerSettings.SettingsData
-  }
-}
-
-export function create(): ServerFactory {
+export function create(appState: AppState) {
+  const resolverLogger = log.child('graphql')
+  const settings = createServerSettingsManager()
   const express = createExpress()
-  let server: BaseServer | null = null
   const state = {
-    settings: ServerSettings.defaultSettings(),
+    running: false,
+    httpServer: HTTP.createServer(),
   }
 
   return {
-    express,
-    async setupAndStart(opts: {
-      schema: GraphQL.GraphQLSchema
-      plugins: Plugin.RuntimeContributions[]
-      contextContributors: ContextContributor<any>[]
-    }) {
-      const context = contextFactory(opts.contextContributors, opts.plugins)
+    private: {
+      settings,
+      state,
+      assemble(loadedRuntimePlugins: Plugin.RuntimeContributions[], schema: GraphQLSchema) {
+        state.httpServer.on('request', express)
 
-      server = setupExpress(express, {
-        ...state.settings,
-        schema: opts.schema,
-        context,
-      })
+        if (settings.data.playground) {
+          express.get(
+            settings.data.playground.path,
+            createRequestHandlerPlayground({ graphqlEndpoint: settings.data.playground.path })
+          )
+        }
 
-      await server.start()
+        const createContext = createContextCreator(
+          appState.schemaComponent.contextContributors,
+          loadedRuntimePlugins
+        )
 
-      DevMode.sendServerReadySignalToDevModeMaster()
-    },
-    stop() {
-      if (!server) {
-        log.warn('You called `server.stop` before calling `server.start`')
-        return Promise.resolve()
-      }
+        express.use(
+          settings.data.path,
+          createExpressGraphql((req) => {
+            return createContext(req).then((context) => ({
+              ...settings,
+              context: context,
+              schema: schema,
+              customFormatErrorFn: (error: Error) => {
+                const colorlessMessage = stripAnsi(error.message)
 
-      return server.stop()
-    },
-    settings: {
-      change(newSettings) {
-        state.settings = ServerSettings.changeSettings(state.settings, newSettings)
+                if (process.env.NEXUS_STAGE === 'dev') {
+                  resolverLogger.error(error.stack ?? error.message)
+                } else {
+                  resolverLogger.error('An exception occured in one of your resolver', {
+                    error: error.stack ? stripAnsi(error.stack) : colorlessMessage,
+                  })
+                }
+
+                error.message = colorlessMessage
+
+                return error
+              },
+            }))
+          })
+        )
       },
-      data: state.settings,
+      async start() {
+        await httpListen(state.httpServer, { port: settings.data.port, host: settings.data.host })
+
+        // About !
+        // 1. We do not support listening on unix domain sockets so string
+        //    value will never be present here.
+        // 2. We are working within the listen callback so address will not be null
+        const address = state.httpServer.address()! as Net.AddressInfo
+
+        settings.data.startMessage({
+          port: address.port,
+          host: address.address,
+          ip: address.address,
+          path: settings.data.path,
+          playgroundPath: settings.data.playground ? settings.data.playground.path : undefined,
+        })
+      },
+      async stop() {
+        if (!state.running) {
+          log.warn('You called `server.stop` but the server was not running.')
+          return Promise.resolve()
+        }
+        await httpClose(state.httpServer)
+        state.running = false
+      },
+    },
+    public: {
+      express,
     },
   }
 }
 
 type AnonymousRequest = Record<string, any>
+
 type AnonymousContext = Record<string, any>
 
 type ContextCreator<
@@ -240,8 +113,11 @@ type ContextCreator<
   Context extends AnonymousContext = AnonymousContext
 > = (req: Req) => Promise<Context>
 
-function contextFactory(
-  contextContributors: ContextContributor<any>[],
+/**
+ * Combine all the context contributions defined in the app and in plugins.
+ */
+function createContextCreator(
+  contextContributors: ContextContributor[],
   plugins: Plugin.RuntimeContributions[]
 ): ContextCreator {
   const createContext: ContextCreator = async (req) => {
@@ -258,7 +134,7 @@ function contextFactory(
     // Integrate context from app context api
     // TODO good runtime feedback to user if something goes wrong
     for (const contextContributor of contextContributors) {
-      const contextContribution = await contextContributor((req as unknown) as Request)
+      const contextContribution = await contextContributor(req as any)
 
       Object.assign(context, contextContribution)
     }
@@ -269,4 +145,24 @@ function contextFactory(
   }
 
   return createContext
+}
+
+function httpListen(server: HTTP.Server, options: Net.ListenOptions): Promise<void> {
+  return new Promise((res, rej) => {
+    server.listen(options, () => {
+      res()
+    })
+  })
+}
+
+function httpClose(server: HTTP.Server): Promise<void> {
+  return new Promise((res, rej) => {
+    server.close((err) => {
+      if (err) {
+        rej(err)
+      } else {
+        res()
+      }
+    })
+  })
 }

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -58,6 +58,7 @@ export type SettingsData = Omit<Utils.DeepRequired<SettingsInput>, 'host' | 'pla
 }
 
 export const defaultPlaygroundPath = '/'
+
 export const defaultPlaygroundSettings: () => Readonly<Required<PlaygroundSettings>> = () =>
   Object.freeze({
     path: defaultPlaygroundPath,
@@ -148,3 +149,17 @@ export function changeSettings(oldSettings: SettingsData, newSettings: SettingsI
     playground,
   }
 }
+
+export function createServerSettingsManager() {
+  const data = defaultSettings()
+  const change = (newSettings: SettingsInput) => {
+    return changeSettings(data, newSettings)
+  }
+
+  return {
+    change,
+    data,
+  }
+}
+
+export type ServerSettingsManager = ReturnType<typeof createServerSettingsManager>

--- a/src/runtime/settings/index.ts
+++ b/src/runtime/settings/index.ts
@@ -1,0 +1,83 @@
+import * as Logger from '@nexus/logger'
+import { cloneDeep } from 'lodash'
+import * as Schema from '../schema'
+import { SchemaSettingsManager } from '../schema/settings'
+import * as Server from '../server'
+import { ServerSettingsManager } from '../server/settings'
+
+type SettingsInput = {
+  logger?: Logger.SettingsInput
+  schema?: Schema.SettingsInput
+  server?: Server.SettingsInput
+}
+
+export type SettingsData = Readonly<{
+  logger: Logger.SettingsData
+  schema: Schema.SettingsData
+  server: Server.SettingsData
+}>
+
+/**
+ * todo
+ */
+export type Settings = {
+  /**
+   * todo
+   */
+  original: SettingsData
+  /**
+   * todo
+   */
+  current: SettingsData
+  /**
+   * todo
+   */
+  change(newSetting: SettingsInput): void
+}
+
+/**
+ * Create an app settings component.
+ *
+ * @remarks
+ *
+ * The app settings component centralizes settings management of all other
+ * components. Therefore it depends on the other components. It requires their
+ * settings managers.
+ */
+export function create({
+  schemaSettings,
+  serverSettings,
+  log,
+}: {
+  schemaSettings: SchemaSettingsManager
+  serverSettings: ServerSettingsManager
+  log: Logger.RootLogger
+}) {
+  const settings: Settings = {
+    change(newSettings) {
+      if (newSettings.logger) {
+        log.settings(newSettings.logger)
+      }
+      if (newSettings.schema) {
+        schemaSettings.change(newSettings.schema)
+      }
+      if (newSettings.server) {
+        serverSettings.change(newSettings.server)
+      }
+    },
+    current: {
+      logger: log.settings,
+      schema: schemaSettings.data,
+      server: serverSettings.data,
+    },
+    original: cloneDeep({
+      logger: log.settings,
+      schema: schemaSettings.data,
+      server: serverSettings.data,
+    }),
+  }
+
+  return {
+    public: settings,
+  }
+}

--- a/src/runtime/start/dev-runner.ts
+++ b/src/runtime/start/dev-runner.ts
@@ -1,8 +1,7 @@
 import * as ts from 'typescript'
 import * as Layout from '../../lib/layout'
 import { transpileModule } from '../../lib/tsc'
-import type { InternalApp } from '../app'
-import * as Server from '../server'
+import type { PrivateApp } from '../app'
 import { createStartModuleContent, StartModuleOptions } from './start-module'
 
 export interface DevRunner {
@@ -22,7 +21,7 @@ export interface DevRunner {
 
 export function createDevAppRunner(
   layout: Layout.Layout,
-  appSingleton: InternalApp,
+  appSingleton: PrivateApp,
   opts?: {
     catchUnhandledErrors?: StartModuleOptions['catchUnhandledErrors']
   }
@@ -37,7 +36,7 @@ export function createDevAppRunner(
     layout: layout,
     absoluteModuleImports: true,
     runtimePluginManifests: [],
-    catchUnhandledErrors: opts?.catchUnhandledErrors
+    catchUnhandledErrors: opts?.catchUnhandledErrors,
   })
 
   const transpiledStartModule = transpileModule(startModule, {
@@ -50,7 +49,7 @@ export function createDevAppRunner(
     start: () => {
       return eval(transpiledStartModule)
     },
-    stop: () => appSingleton.server.stop(),
+    stop: () => appSingleton.stop(),
     port: appSingleton.settings.current.server.port,
   }
 }

--- a/src/runtime/start/start-module.ts
+++ b/src/runtime/start/start-module.ts
@@ -151,10 +151,8 @@ export function createStartModuleContent(config: StartModuleConfig): string {
 
   content += EOL + EOL + EOL
   content += stripIndent`
-    // Boot the server if the user did not already.
-    if (app.__state.isWasServerStartCalled === false) {
-      app.server.start()
-    }
+    app.assemble()
+    app.start()
   `
 
   log.trace('created start module', { content })


### PR DESCRIPTION
Motivations:

- decouple concept of starting server from assembly to support future serverless feature #782 
- assembly is the process of gathering the lazy state into a final runnable one 
- settings is now a component like schema and server
- the components are designed to look a lot more symmetrical now
- root app state is passed down to components which attach their namespaced state to, easier to reason about, think redux
- introduce concept of checks that runs after schema assembly

BREAKING CHANGE:

- `server.start` and `server.stop` are no longer exposed. If you had a use-case for them please open an issue to discuss.

#### TODO

- [x] docs
- [x] tests