### PR TITLE
fix + enhance: test context

### DIFF
--- a/docs/api/modules/testing.md
+++ b/docs/api/modules/testing.md
@@ -2,8 +2,62 @@
 
 ## `createTestContext`
 
-todo
+Setup a test context providing utilities to query against your GraphQL API.
+
+This context can be augmented by plugins.
+
+##### Signature
+
+```ts
+function createTestContext(opts?: CreateTestContextOptions): Promise<TestContext>
+```
+
+
+##### Example With Jest
+
+```ts
+import { } from 'nexus/testing'
+
+let ctx: TestContext
+
+beforeAll(async () => {
+  ctx = await createTestContext()
+  await ctx.server.start()
+})
+
+afterAll(async () => {
+  await ctx.server.stop()
+})
+
+test('hello', async () => {
+  const result = await ctx.query(`{ hello }`)
+
+  expect(result).toMatchInlineSnapshot()
+})
+```
+
+## `I` CreateTestContextOptions
+
+```ts
+export interface CreateTestContextOptions {
+  /**
+   * A path to the entrypoint of your app. Only necessary if the entrypoint falls outside of Nexus convention.
+   * You should typically use this if you're using `nexus dev --entrypoint` or `nexus build --entrypoint`.
+   */
+  entrypointPath?: string
+}
+```
 
 ## `I` `TestContext`
 
-todo
+```ts
+export interface TestContext {
+  app: {
+    query: <T = any>(query: string, variables: Record<string, any>): Promise<T>
+    server: {
+      start: () => Promise<void>
+      stop: () => Promise<void>
+    }
+  }
+}
+```

--- a/src/runtime/schema/settings.ts
+++ b/src/runtime/schema/settings.ts
@@ -61,7 +61,10 @@ export type SettingsInput = {
 
 export type SettingsData = SettingsInput
 
-export function changeSettings(state: SettingsData, newSettings: SettingsInput) {
+/**
+ * Mutate the settings data
+ */
+export function changeSettings(state: SettingsData, newSettings: SettingsInput): void {
   if (newSettings.nullable) {
     if (state.nullable === undefined) {
       state.nullable = {}

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -85,6 +85,7 @@ export function create(appState: AppState) {
       },
       async start() {
         await httpListen(state.httpServer, { port: settings.data.port, host: settings.data.host })
+        state.running = true
 
         // About !
         // 1. We do not support listening on unix domain sockets so string

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -43,6 +43,10 @@ declare global {
 export type TestContext = NexusTestContextRoot
 
 export interface CreateTestContextOptions {
+  /**
+   * A path to the entrypoint of your app. Only necessary if the entrypoint falls outside of Nexus conventions.
+   * You should typically use this if you're using `nexus dev --entrypoint` or `nexus build --entrypoint`.
+   */
   entrypointPath?: string
 }
 
@@ -53,17 +57,17 @@ export interface CreateTestContextOptions {
  *
  * With jest
  * ```
- * import { setupTest, TestContext } from 'nexus/testing'
+ * import { createTestContext, TestContext } from 'nexus/testing'
  *
- * let testCtx: TestContext
+ * let ctx: TestContext
  *
  * beforeAll(async () => {
- *  testCtx = await setupTest()
- *  await testCtx.server.start()
+ *  ctx = await createTestContext()
+ *  await ctx.server.start()
  * })
  *
  * afterAll(async () => {
- *  await testCtx.server.stop()
+ *  await ctx.server.stop()
  * })
  * ```
  */

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -42,6 +42,10 @@ declare global {
 
 export type TestContext = NexusTestContextRoot
 
+export interface CreateTestContextOptions {
+  entrypointPath?: string
+}
+
 /**
  * Setup a test context providing utilities to query against your GraphQL API
  *
@@ -63,12 +67,12 @@ export type TestContext = NexusTestContextRoot
  * })
  * ```
  */
-export async function createTestContext(): Promise<TestContext> {
+export async function createTestContext(opts?: CreateTestContextOptions): Promise<TestContext> {
   // Guarantee that development mode features are on
   process.env.NEXUS_STAGE = 'dev'
 
   // todo figure out some caching system here, e.g. imagine jest --watch mode
-  const layout = await Layout.create()
+  const layout = await Layout.create({ entrypointPath: opts?.entrypointPath })
   const pluginManifests = await Plugin.getUsedPlugins(layout)
   const randomPort = await getPort({ port: getPort.makeRange(4000, 6000) })
   const app = require('../index').default as PrivateApp


### PR DESCRIPTION
closes #803 

This PR will be merged as rebase. It does a couple of things:

- Fixes server settings that were no longer working (regression)
- Fixes `app.stop()` which was always warning that the server wasn't run because `running` was never set to true (regression)
- Fixes #803 where the app singleton wasn't properly required (regression)
- Add an option to specify a custom entrypoint if one is needed and used with `nexus dev | build`
- Makes sure that if the user app calls `settings.change({ server: { ... } })`, the test context server settings are still applied

#### TODO

- [x] docs
- [ ] tests
