### PR TITLE
feat: publish esm builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,8 @@ yarn-error.log*
 
 .DS_Store
 .vscode
-dist
-tsconfig.tsbuildinfo
+dist*
+*.tsbuildinfo
 
 .now
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "module": "dist-esm/index.js",
   "files": [
     "/dist",
+    "/dist-esm",
     "/scripts",
     "README.md",
     "yarn.lock",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "bugs": "https://github.com/graphql-nexus/nexus/issues",
   "license": "MIT",
   "main": "dist/index.js",
+  "module": "dist-esm/index.js",
   "files": [
     "/dist",
     "/scripts",
@@ -94,8 +95,8 @@
     "release:preview": "dripip preview",
     "release:pr": "dripip pr",
     "format": "prettier --write '.'",
-    "build": "yarn -s clean && node scripts/build-module-facades && tsc -b",
-    "clean": "git clean -fX && rm -rf dist",
+    "build": "yarn -s clean && node scripts/build-module-facades && tsc --project tsconfig.cjs.json && tsc --project tsconfig.esm.json",
+    "clean": "git clean -fX && rm -rf dist*",
     "postpublish": "yarn -s clean",
     "postinstall": "node scripts/postinstall",
     "prepublishOnly": "yarn -s build",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "ES2015",
+    "outDir": "dist-esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "outDir": "dist",
     "rootDir": "src",
     "allowJs": true,
     "resolveJsonModule": true


### PR DESCRIPTION
closes #829

This does not make the sub-modules esm compatible. Maybe there is a way to make other package dirs have esm builds, but so far not aware. We'll see how this goes. Most use-cases should be for the default (main) dir.

