### PR TITLE
[WIP] feat: support using custom http server

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "postpublish": "yarn clean",
     "postinstall": "node scripts/postinstall",
     "prepublishOnly": "yarn build",
+    "prepare": "rm -rf dist* && node scripts/build-module-facades && tsc --project tsconfig.cjs.json && tsc --project tsconfig.esm.json",
     "test": "LOG_PRETTY=true DEBUG=true jest --verbose --testTimeout 360000 --forceExit",
     "test:unit": "yarn test src",
     "dev:test": "yarn test --watch src",

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -29,7 +29,6 @@ export interface Server {
 
 export const defaultState = {
   running: false,
-  httpServer: HTTP.createServer(),
   createContext: null,
 }
 
@@ -71,7 +70,7 @@ export function create(appState: AppState) {
         internalServer.private.state = { ...defaultState }
       },
       assemble(loadedRuntimePlugins: Plugin.RuntimeContributions[], schema: GraphQLSchema) {
-        state.httpServer.on('request', express)
+        settings.data.httpServer.on('request', express)
 
         if (settings.data.playground) {
           express.get(
@@ -95,14 +94,14 @@ export function create(appState: AppState) {
         return { createContext }
       },
       async start() {
-        await httpListen(state.httpServer, { port: settings.data.port, host: settings.data.host })
+        await httpListen(settings.data.httpServer, { port: settings.data.port, host: settings.data.host })
         state.running = true
 
         // About !
         // 1. We do not support listening on unix domain sockets so string
         //    value will never be present here.
         // 2. We are working within the listen callback so address will not be null
-        const address = state.httpServer.address()! as Net.AddressInfo
+        const address = settings.data.httpServer.address()! as Net.AddressInfo
 
         settings.data.startMessage({
           port: address.port,
@@ -118,7 +117,7 @@ export function create(appState: AppState) {
           log.warn('You called `server.stop` but the server was not running.')
           return Promise.resolve()
         }
-        await httpClose(state.httpServer)
+        await httpClose(settings.data.httpServer)
         state.running = false
       },
     },

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -1,6 +1,7 @@
 import * as Process from '../../lib/process'
 import * as Utils from '../../lib/utils'
 import { log as serverLogger } from './logger'
+import * as HTTP from 'http'
 
 const log = serverLogger.child('settings')
 
@@ -13,6 +14,10 @@ export type SettingsInput = {
    * todo
    */
   port?: number
+  /**
+   * Use an existing http server?
+   */
+  httpServer?: HTTP.Server | undefined
   /**
    * Host the server should be listening on.
    */
@@ -86,6 +91,7 @@ export const defaultSettings: () => Readonly<SettingsData> = () => {
     },
     playground: process.env.NODE_ENV === 'production' ? false : defaultPlaygroundSettings(),
     path: '/graphql',
+    httpServer: HTTP.createServer(),
   }
 }
 
@@ -147,6 +153,7 @@ export function changeSettings(state: SettingsData, newSettings: SettingsInput):
   state.path = validateGraphQLPath(updatedSettings.path)
   state.port = updatedSettings.port
   state.startMessage = updatedSettings.startMessage
+  state.httpServer = updatedSettings.httpServer
 }
 
 export function createServerSettingsManager() {


### PR DESCRIPTION
This supports passing a custom http server into nexus so it can be hooked into other "plugins" or services outside nexus that need to use the same server. Right now nexus creates its own server and doesn't expose it.

Why?
By allowing for a custom http server I was able to pass the same server into a subscription plugin im testing ([nexus-plugin-subscriptions](https://github.com/danielmahon/nexus-plugin-subscriptions)) to support subscriptions on the same port using `subscriptions-transport-ws`.

Usage
```dart
import { subscriptions } from 'nexus-plugin-subscriptions';
import * as HTTP from 'http';

const httpServer = HTTP.createServer();

// Nexus settings
settings.change({
  server: { httpServer, playground: true },
});

// Nexus plugins
use(prisma({ client: { options: { log: ['query'] } } }));
use(permissions());
use(
  subscriptions({
    httpServer,
    onConnect: () => {
      log.info('client connected');
    },
    onDisconnect: () => {
      log.info('client disconnected');
    },
  }),
);
```

Other solutions:
1. Nexus exposes its http server (side effects?, hard to control lifecycle state when using exposed server?)
2. Pass server instance into a plugin lifecycle method?

Signed-off-by: Daniel Mahon <danielmahon@users.noreply.github.com>

#### TODO

- [ ] docs
- [ ] tests
