### PR TITLE
feat(plugin): manifest input defaults

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,75 @@ todo
 
 todo
 
+## Plugins
+
+### Loading Flow
+
+todo  
+what follows is a stub
+
+1. capture the used plugins in the app
+1. validate entrypoints
+1. transform entrypoints into manifests
+1. for each dimension (work, test, run) in the manifest
+   1. import it
+   1. catch any import errors
+   1. validate imported value
+   1. load plugin
+   1. catch any load errors
+
+### Glossary
+
+#### Entrypoint
+
+A plugin entrypoint is responsible for returning the plugin's manifest. This is what users actually deal with at the app layer.
+
+```ts
+import { prisma } from 'nexus-plugin-prisma'
+//       ~~~~~~ <------------- The entrypoint, returns a manifest
+import { use } from 'nexus'
+
+use(prisma())
+```
+
+#### Manifest
+
+A plugin manifest describes logistical information about a plugin like where its package file is located on disk, what versions of Nexus it is compatible with.
+
+Plugin manifests are returned by plugin entrypoints.
+
+```ts
+import { prisma } from 'nexus-plugin-prisma'
+
+const prismaPluginManifest = prisma()
+```
+
+This lazy approach allows Nexus the flexibility it needs to provide features like automatic environment variable plugin settings injection and tree-shaking.
+
+There are two views of the manifest. Plugin authors see a partial construct with optional fields that they may but do not _have_ to provide. Internally, manifests are normalized with defaults. This approach allows us to have strong conventions but allow them to be escaped if necessary.
+
+#### Dimension
+
+A plugin dimension represents a high-level area of plugin concern that are separated by module from other dimensions. In other words, each dimension has its own entrypoint. Nexus will directly import it. A dimension is found by Nexus from Nexus reading the Plugin manifest.
+
+There are three dimensions: worktime, testtime, and runtime. Worktime allows plugins to tap into the CLI, the builder, dev mode, and more. Testtime allows plugins to tap into features of the Nexus testing component. Runtime allows plugins to tap into the API.
+
+Directionally Nexus is on a good track, but there is work still left to do. The names are a bit confusing when you dig into the details, and the supposed separation between worktime/runtime has undesirable "loopholes" because of reflection. Details;
+
+      1. Runtime dimension does not mean plugging exclusively into what is run in your production code. There are actually reasons to plug into the runtime for ostensibly worktime beneit... This is due to Nexus' so-called reflection system, wherein the app is run in the background during development for development purposes.
+
+      2. The rationale for splitting worktime from runtime is clear, tree-shaking alone makes the case for it. However the separation between worktime and testing is less clear, perhaps nonsense, and so may be revisited in the future.
+
+      3. We've talked about motivation for separating worktime from runtime, yet there are runtime parts for worktime (reflection). What this means is that expensive dependencies can make there way into the runtime dimension that a user should actually _not_ be paying for in production runtime.
+
+#### Lens
+
+A plugin lens is just a specialized api into a subset of Nexus to hook into, extend, manipulate, and react to it during execution. The name "lens" is arbitrary. The choice comes from it being "view" into Nexus. Each dimension has its own specialized lens.
+
+#### Dimension Entrypoint
+
+Just like the plugin has a top level entrypoint so to does each dimension within the plugin have its own entrypoint. These sub-entrypoints can be thought as sub-plugins, with the top-level plugin just being a grouping mechanism.
+
 ## Build Flow
 
 1. The app layout is calculated  
@@ -30,21 +99,6 @@ todo
    - paths are relative
    - typescript not hooked into module extensions
    - plugins are imported for tree-shaking
-
-## Plugin Loading Flow
-
-todo  
-what follows is a stub
-
-1. capture the used plugins in the app
-1. validate entrypoints
-1. transform entrypoints into manifests
-1. for each dimension (work, test, run) in the manifest
-   1. import it
-   1. catch any import errors
-   1. validate imported value
-   1. load plugin
-   1. catch any load errors
 
 ## Glossary
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,11 +27,11 @@ what follows is a stub
 
 #### Entrypoint
 
-A plugin entrypoint is responsible for returning the plugin's manifest. This is what users actually deal with at the app layer.
+A plugin entrypoint is responsible for returning the plugin's manifest input. This is what users actually deal with at the app layer.
 
 ```ts
 import { prisma } from 'nexus-plugin-prisma'
-//       ~~~~~~ <------------- The entrypoint, returns a manifest
+//       ~~~~~~ <------------- The entrypoint, returns a manifest input
 import { use } from 'nexus'
 
 use(prisma())
@@ -39,19 +39,21 @@ use(prisma())
 
 #### Manifest
 
-A plugin manifest describes logistical information about a plugin like where its package file is located on disk, what versions of Nexus it is compatible with.
+A plugin manifest describes logistical information about a plugin like where its package file is located on disk, what versions of Nexus it is compatible with, and more.
 
-Plugin manifests are returned by plugin entrypoints.
+Plugin manifests are created by Nexus by processing the manifest inputs returned by plugin entrypoints.
 
 ```ts
 import { prisma } from 'nexus-plugin-prisma'
 
-const prismaPluginManifest = prisma()
+const prismaPluginManifestInput = prisma()
 ```
 
 This lazy approach allows Nexus the flexibility it needs to provide features like automatic environment variable plugin settings injection and tree-shaking.
 
-There are two views of the manifest. Plugin authors see a partial construct with optional fields that they may but do not _have_ to provide. Internally, manifests are normalized with defaults. This approach allows us to have strong conventions but allow them to be escaped if necessary.
+#### Manifest Input
+
+A manifest input is the view of manifests that plugin authors work with. It models the minimum information that Nexus needs to build the plugin manifest. It is also more human friendly, for example minimizing the number of required fields. Developer experience is not the primary motivation here however. We want Nexus to control as much as possible, so the less the human has to specify the more we achieve this goal. For example we ask for a path to package json rather than the contents of it. We want Nexus to be the one that reads it, when and how it wants.
 
 #### Dimension
 
@@ -61,11 +63,11 @@ There are three dimensions: worktime, testtime, and runtime. Worktime allows plu
 
 Directionally Nexus is on a good track, but there is work still left to do. The names are a bit confusing when you dig into the details, and the supposed separation between worktime/runtime has undesirable "loopholes" because of reflection. Details;
 
-      1. Runtime dimension does not mean plugging exclusively into what is run in your production code. There are actually reasons to plug into the runtime for ostensibly worktime beneit... This is due to Nexus' so-called reflection system, wherein the app is run in the background during development for development purposes.
+1.  Runtime dimension does not mean plugging exclusively into what is run in your production code. There are actually reasons to plug into the runtime for ostensibly worktime beneit... This is due to Nexus' so-called reflection system, wherein the app is run in the background during development for development purposes.
 
-      2. The rationale for splitting worktime from runtime is clear, tree-shaking alone makes the case for it. However the separation between worktime and testing is less clear, perhaps nonsense, and so may be revisited in the future.
+2.  The rationale for splitting worktime from runtime is clear, tree-shaking alone makes the case for it. However the separation between worktime and testing is less clear, perhaps nonsense, and so may be revisited in the future.
 
-      3. We've talked about motivation for separating worktime from runtime, yet there are runtime parts for worktime (reflection). What this means is that expensive dependencies can make there way into the runtime dimension that a user should actually _not_ be paying for in production runtime.
+3.  We've talked about motivation for separating worktime from runtime, yet there are runtime parts for worktime (reflection). What this means is that expensive dependencies can make there way into the runtime dimension that a user should actually _not_ be paying for in production runtime.
 
 #### Lens
 
@@ -74,6 +76,12 @@ A plugin lens is just a specialized api into a subset of Nexus to hook into, ext
 #### Dimension Entrypoint
 
 Just like the plugin has a top level entrypoint so to does each dimension within the plugin have its own entrypoint. These sub-entrypoints can be thought as sub-plugins, with the top-level plugin just being a grouping mechanism.
+
+### Diagrams
+
+#### Plugin Tree Shaking
+
+![plugin-tree-shaking](https://dsc.cloud/661643/plugin-tree-shaking.png)
 
 ## Build Flow
 

--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -53,7 +53,7 @@ export async function runLocalHandOff(): Promise<void> {
   const parentData = await loadDataFromParentProcess()
   const layout = await Layout.create()
   const pluginM = await Plugin.getUsedPlugins(layout)
-  const plugins = Plugin.importAndLoadWorktimePlugins(pluginM, layout)
+  const plugins = await Plugin.importAndLoadWorktimePlugins(pluginM, layout)
   log.trace('plugins', { plugins })
 
   // TODO select a template
@@ -466,7 +466,9 @@ async function scaffoldBaseFiles(options: InternalConfig) {
     // Having at least one of these satisfies minimum Nexus requirements.
     // We put both to setup vscode debugger config with an entrypoint that is
     // unlikely to change.
-    fs.writeAsync(appEntrypointPath, stripIndent`
+    fs.writeAsync(
+      appEntrypointPath,
+      stripIndent`
       /**
        * This file is your server entrypoint. Don't worry about its emptyness, Nexus handles everything for you.
        * However, if you need to add settings, enable plugins, schema middleware etc, this is place to do it.
@@ -507,7 +509,8 @@ async function scaffoldBaseFiles(options: InternalConfig) {
       // import { prisma } from 'nexus-plugin-prisma'
       //
       // use(prisma())
-    `),
+    `
+    ),
     fs.writeAsync(path.join(options.sourceRoot, Layout.schema.CONVENTIONAL_SCHEMA_FILE_NAME), ''),
     // An exhaustive .gitignore tailored for Node can be found here:
     // https://github.com/github/gitignore/blob/master/Node.gitignore

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -6,11 +6,11 @@ import { rootLogger } from '../../lib/nexus-logger'
 import { ownPackage } from '../../lib/own-package'
 import * as Plugin from '../../lib/plugin'
 import { fatal } from '../../lib/process'
+import * as Reflection from '../../lib/reflection'
 import { transpileModule } from '../../lib/tsc'
+import { simpleDebounce } from '../../lib/utils'
 import { createWatcher } from '../../lib/watcher'
 import { createStartModuleContent } from '../../runtime/start'
-import * as Reflection from '../../lib/reflection'
-import { simpleDebounce } from '../../lib/utils'
 
 const log = rootLogger.child('dev')
 
@@ -46,7 +46,7 @@ export class Dev implements Command {
       fatal('reflection failed', { error: pluginReflectionResult.error })
     }
 
-    const worktimePlugins = Plugin.importAndLoadWorktimePlugins(pluginReflectionResult.plugins, layout)
+    const worktimePlugins = await Plugin.importAndLoadWorktimePlugins(pluginReflectionResult.plugins, layout)
 
     for (const p of worktimePlugins) {
       await p.hooks.dev.onStart?.()

--- a/src/lib/build/build.ts
+++ b/src/lib/build/build.ts
@@ -61,7 +61,7 @@ export async function buildNexusApp(settings: BuildSettings) {
   }
 
   const { plugins } = pluginReflection
-  const worktimePlugins = Plugin.importAndLoadWorktimePlugins(plugins, layout)
+  const worktimePlugins = await Plugin.importAndLoadWorktimePlugins(plugins, layout)
 
   for (const p of worktimePlugins) {
     await p.hooks.build.onStart?.()
@@ -87,7 +87,8 @@ export async function buildNexusApp(settings: BuildSettings) {
 
   compile(tsBuilder, layout, { removePreviousBuild: false })
 
-  const runtimePluginManifests = plugins.map(Plugin.entrypointToManifest).filter((pm) => pm.runtime)
+  const pluginManifests = await Promise.all(plugins.map(Plugin.getPluginManifest))
+  const runtimePluginManifests = pluginManifests.filter((pm) => pm.runtime)
 
   if (!layout.tsConfig.content.options.noEmit) {
     await writeStartModule({

--- a/src/lib/plugin/index.ts
+++ b/src/lib/plugin/index.ts
@@ -3,5 +3,6 @@ export {
   importAndLoadTesttimePlugins,
   importAndLoadWorktimePlugins,
 } from './load'
+export * from './manifest'
 export * from './types'
 export * from './utils'

--- a/src/lib/plugin/load.ts
+++ b/src/lib/plugin/load.ts
@@ -4,16 +4,17 @@ import { partition } from '../utils'
 import { importPluginDimension } from './import'
 import { createBaseLens, createRuntimeLens, createWorktimeLens } from './lens'
 import { Plugin } from './types'
-import { entrypointToManifest } from './utils'
+import { getPluginManifest } from './utils'
 
 const log = rootLogger.child('plugin')
 
 /**
  * Fully import and load the runtime plugins, if any, amongst the given plugins.
  */
-export function importAndLoadRuntimePlugins(plugins: Plugin[]) {
-  return filterValidPlugins(plugins)
-    .map(entrypointToManifest)
+export async function importAndLoadRuntimePlugins(plugins: Plugin[]) {
+  const validPlugins = filterValidPlugins(plugins)
+  const pluginManifests = await Promise.all(validPlugins.map(getPluginManifest))
+  return pluginManifests
     .filter((m) => m.runtime)
     .map((m) => {
       return {
@@ -30,9 +31,11 @@ export function importAndLoadRuntimePlugins(plugins: Plugin[]) {
 /**
  * Fully import and load the worktime plugins, if any, amongst the given plugins.
  */
-export function importAndLoadWorktimePlugins(plugins: Plugin[], layout: Layout.Layout) {
-  return filterValidPlugins(plugins)
-    .map(entrypointToManifest)
+export async function importAndLoadWorktimePlugins(plugins: Plugin[], layout: Layout.Layout) {
+  const validPlugins = filterValidPlugins(plugins)
+  const pluginManifests = await Promise.all(validPlugins.map(getPluginManifest))
+
+  return pluginManifests
     .filter((m) => m.worktime)
     .map((m) => {
       return {
@@ -58,9 +61,11 @@ export function importAndLoadWorktimePlugins(plugins: Plugin[], layout: Layout.L
 /**
  * Fully import and load the testtime plugins, if any, amongst the given plugins.
  */
-export function importAndLoadTesttimePlugins(plugins: Plugin[]) {
-  return filterValidPlugins(plugins)
-    .map(entrypointToManifest)
+export async function importAndLoadTesttimePlugins(plugins: Plugin[]) {
+  const validPlugins = filterValidPlugins(plugins)
+  const pluginManifests = await Promise.all(validPlugins.map(getPluginManifest))
+
+  return pluginManifests
     .filter((m) => m.testtime)
     .map((m) => {
       return {

--- a/src/lib/plugin/load.ts
+++ b/src/lib/plugin/load.ts
@@ -3,8 +3,8 @@ import { rootLogger } from '../nexus-logger'
 import { partition } from '../utils'
 import { importPluginDimension } from './import'
 import { createBaseLens, createRuntimeLens, createWorktimeLens } from './lens'
+import { getPluginManifest } from './manifest'
 import { Plugin } from './types'
-import { getPluginManifest } from './utils'
 
 const log = rootLogger.child('plugin')
 

--- a/src/lib/plugin/manifest.ts
+++ b/src/lib/plugin/manifest.ts
@@ -2,12 +2,9 @@ import { isLeft, toError, tryCatch } from 'fp-ts/lib/Either'
 import * as fs from 'fs-jetpack'
 import * as Path from 'path'
 import { PackageJson } from 'type-fest'
-import { rootLogger } from '../nexus-logger'
 import { fatal } from '../process'
 import { getPackageJsonMain } from '../utils'
 import { Dimension, DimensionEntrypointLocation, Manifest, Plugin, ValidatedPackageJson } from './types'
-
-const log = rootLogger.child('plugin')
 
 /**
  * Normalize a raw plugin manifest.

--- a/src/lib/plugin/manifest.ts
+++ b/src/lib/plugin/manifest.ts
@@ -1,0 +1,114 @@
+import { isLeft, toError, tryCatch } from 'fp-ts/lib/Either'
+import * as fs from 'fs-jetpack'
+import * as Path from 'path'
+import { PackageJson } from 'type-fest'
+import { rootLogger } from '../nexus-logger'
+import { fatal } from '../process'
+import { getPackageJsonMain } from '../utils'
+import { Dimension, DimensionEntrypointLocation, Manifest, Plugin, ValidatedPackageJson } from './types'
+
+const log = rootLogger.child('plugin')
+
+/**
+ * Normalize a raw plugin manifest.
+ *
+ * @remarks
+ *
+ * The raw plugin manifest is what the plugin author defined. This supplies
+ * defaults and fulfills properties to produce standardized manifest data.
+ */
+export async function getPluginManifest(plugin: Plugin): Promise<Manifest> {
+  const errPackageJson = tryCatch(() => require(plugin.packageJsonPath) as PackageJson, toError)
+
+  if (isLeft(errPackageJson)) {
+    fatal(
+      createGetManifestError(
+        addErrorMessageContext(`Failed to read the the plugin's package.json file.`, errPackageJson.left)
+      ),
+      { plugin }
+    )
+  }
+
+  const packageJson = errPackageJson.right
+
+  if (!packageJson.name) {
+    fatal(createGetManifestError(new Error(`\`name\` property is missing in package.json`)), {
+      packageJson: {
+        data: packageJson,
+        path: plugin.packageJsonPath,
+      },
+    })
+  }
+
+  if (!packageJson.main) {
+    fatal(createGetManifestError(new Error(`\`main\` property is missing in package.json`)), {
+      packageJson: {
+        data: packageJson,
+        path: plugin.packageJsonPath,
+      },
+    })
+  }
+
+  const validatedPackageJson = packageJson as ValidatedPackageJson
+
+  const [worktime, runtime, testtime] = await Promise.all([
+    getDimensionEntrypointLocation('worktime', validatedPackageJson, plugin),
+    getDimensionEntrypointLocation('runtime', validatedPackageJson, plugin),
+    getDimensionEntrypointLocation('testtime', validatedPackageJson, plugin),
+  ])
+
+  return {
+    name: packageJson.name,
+    settings: (plugin as any).settings ?? null,
+    packageJsonPath: plugin.packageJsonPath,
+    packageJson: validatedPackageJson,
+    worktime,
+    testtime,
+    runtime,
+  }
+}
+
+/**
+ * Get the dimension entrypoint location. Take it from the manifest input if
+ * present. Otherwise check on disk for the conventional module.
+ *
+ * The conventional dimension module location is:
+ *
+ * <project-root>/<main dir>/{runtime,worktime,testtime}.js
+ * <project-root>/<main dir>/{runtime,worktime,testtime}/index.js
+ *
+ * The location path extension is not specified to afford plugin author the
+ * index dir style. This means the location path must be passed into a
+ * node-module-resolution functino e.g. `require`. Do not pass it to a raw FS
+ * file read function.
+ */
+async function getDimensionEntrypointLocation(
+  dimensionkind: Dimension,
+  packageJson: ValidatedPackageJson,
+  plugin: Plugin
+): Promise<DimensionEntrypointLocation | null> {
+  if (plugin[dimensionkind]) return plugin[dimensionkind]!
+
+  const dimensionEntrypointPath = Path.join(getPackageJsonMain(packageJson), dimensionkind)
+  const conventionalPath = Path.join(Path.dirname(plugin.packageJsonPath), dimensionEntrypointPath)
+
+  if (await fs.existsAsync(conventionalPath)) {
+    return {
+      module: dimensionEntrypointPath,
+      export: 'plugin',
+    }
+  }
+
+  return null
+}
+
+// helpers
+
+function addErrorMessageContext(additionalMessage: string, error: Error): Error {
+  error.message = `${additionalMessage}\n\n${error.message}`
+  return error
+}
+
+function createGetManifestError(error: Error): Error {
+  return new Error(`An error occured whlie loading one of the plugins you are using.\n\n${error.message}`)
+}

--- a/src/lib/plugin/types/plugin.ts
+++ b/src/lib/plugin/types/plugin.ts
@@ -11,6 +11,26 @@ import {
 
 export type Dimension = 'runtime' | 'worktime' | 'testtime'
 
+/**
+ * The location of a module and export to the entrypoint for the respective
+ * dimension of your plugin.
+ *
+ * Normally, you do **not** need to configure this. Use the following
+ * conventions instead.
+ *
+ * Adjacent to where your plugin entrypoint is, put any of these modules and
+ * Nexus will automatically detect them (the following assumes a plugin
+ * entrypoint of plugin/index.ts):
+ *
+ * ```
+ * <project root>/plugin/runtime.ts
+ * <project root>/plugin/testtime.ts
+ * <project root>/plugin/worktime.ts
+ * <project root>/plugin/runtime/index.ts
+ * <project root>/plugin/testtime/index.ts
+ * <project root>/plugin/worktime/index.ts
+ * ```
+ */
 export interface DimensionEntrypointLocation {
   /**
    * Path of a module. We recommend using `require.resolve()`

--- a/src/lib/plugin/types/plugin.ts
+++ b/src/lib/plugin/types/plugin.ts
@@ -11,7 +11,7 @@ import {
 
 export type Dimension = 'runtime' | 'worktime' | 'testtime'
 
-export interface DimensionEntrypoint {
+export interface DimensionEntrypointLocation {
   /**
    * Path of a module. We recommend using `require.resolve()`
    */
@@ -67,7 +67,7 @@ export interface PluginWithoutSettings {
    * }
    * ```
    */
-  runtime?: DimensionEntrypoint
+  runtime?: DimensionEntrypointLocation
   /**
    * An object pointing to the file responsible for the "worktime" dimension of your plugin.
    *
@@ -80,7 +80,7 @@ export interface PluginWithoutSettings {
    * }
    * ```
    */
-  worktime?: DimensionEntrypoint
+  worktime?: DimensionEntrypointLocation
   /**
    * An object pointing to the file responsible for the "testtime" dimension of your plugin.
    *
@@ -93,7 +93,7 @@ export interface PluginWithoutSettings {
    * }
    * ```
    */
-  testtime?: DimensionEntrypoint
+  testtime?: DimensionEntrypointLocation
   //settingsType?: DimensionEntrypoint
   //frameworkVersion?: string // valid npm version expression
 }
@@ -120,26 +120,44 @@ export type Plugin<Settings = any> =
   | PluginWithRequiredSettings<Settings>
 
 /**
+ * PackageJson type in its post-validated-for-plugin-system form.
+ */
+export type ValidatedPackageJson = {
+  name: string
+  main: string
+} & PackageJson
+
+/**
  * Internal representation of a plugin entrypoint, called a "Manifest"
  *
  * @remarks
  *
- * Whereas plugin entrypoints are designed to ease what API authors must supply
+ * Whereas plugin entrypoints are designed to ease what API authors must supply,
  * manifests are a resolved representation of the entrypoint with all defaults
  * etc. filled.
  */
-export type Manifest = Plugin & {
+export type Manifest = {
   name: string
-  packageJson: PackageJson
-  settings?: any
+  packageJson: ValidatedPackageJson
+  packageJsonPath: string
+  settings: null | Record<string, any>
+  worktime: null | DimensionEntrypointLocation
+  runtime: null | DimensionEntrypointLocation
+  testtime: null | DimensionEntrypointLocation
 }
 
+/**
+ * Utility type to lookup the entrypoint of a dimension of a plugin.
+ */
 export type DimensionToPlugin<D extends Dimension> = {
   runtime: InnerRuntimePlugin
   worktime: InnerWorktimePlugin
   testtime: InnerTesttimePlugin
 }[D]
 
+/**
+ * Utility type to lookup the lens of a dimension of a plugin.
+ */
 export type DimensionToLens<D extends Dimension> = {
   runtime: ReturnType<typeof createRuntimeLens>
   worktime: ReturnType<typeof createWorktimeLens>

--- a/src/lib/plugin/utils.ts
+++ b/src/lib/plugin/utils.ts
@@ -1,108 +1,10 @@
-import { isLeft, toError, tryCatch } from 'fp-ts/lib/Either'
-import * as fs from 'fs-jetpack'
-import * as Path from 'path'
-import { PackageJson } from 'type-fest'
 import * as Layout from '../layout'
 import { rootLogger } from '../nexus-logger'
 import { fatal } from '../process'
 import * as Reflection from '../reflection/reflect'
-import { getPackageJsonMain } from '../utils'
-import { Dimension, DimensionEntrypointLocation, Manifest, Plugin, ValidatedPackageJson } from './types'
+import { Plugin } from './types'
 
 const log = rootLogger.child('plugin')
-
-/**
- * Normalize a raw plugin manifest.
- *
- * @remarks
- *
- * The raw plugin manifest is what the plugin author defined. This supplies
- * defaults and fulfills properties to produce standardized manifest data.
- */
-export async function getPluginManifest(plugin: Plugin): Promise<Manifest> {
-  const errPackageJson = tryCatch(() => require(plugin.packageJsonPath) as PackageJson, toError)
-
-  if (isLeft(errPackageJson)) {
-    fatal(
-      createGetManifestError(
-        addErrorMessageContext(`Failed to read the the plugin's package.json file.`, errPackageJson.left)
-      ),
-      { plugin }
-    )
-  }
-
-  const packageJson = errPackageJson.right
-
-  if (!packageJson.name) {
-    fatal(createGetManifestError(new Error(`\`name\` property is missing in package.json`)), {
-      packageJson: {
-        data: packageJson,
-        path: plugin.packageJsonPath,
-      },
-    })
-  }
-
-  if (!packageJson.main) {
-    fatal(createGetManifestError(new Error(`\`main\` property is missing in package.json`)), {
-      packageJson: {
-        data: packageJson,
-        path: plugin.packageJsonPath,
-      },
-    })
-  }
-
-  const validatedPackageJson = packageJson as ValidatedPackageJson
-
-  const [worktime, runtime, testtime] = await Promise.all([
-    getDimensionEntrypointLocation('worktime', validatedPackageJson, plugin),
-    getDimensionEntrypointLocation('runtime', validatedPackageJson, plugin),
-    getDimensionEntrypointLocation('testtime', validatedPackageJson, plugin),
-  ])
-
-  return {
-    name: packageJson.name,
-    settings: (plugin as any).settings ?? null,
-    packageJsonPath: plugin.packageJsonPath,
-    packageJson: validatedPackageJson,
-    worktime,
-    testtime,
-    runtime,
-  }
-}
-
-/**
- * Get the dimension entrypoint location. Take it from the manifest input if
- * present. Otherwise check on disk for the conventional module.
- *
- * The conventional dimension module location is:
- *
- * <project-root>/<main dir>/{runtime,worktime,testtime}.js
- * <project-root>/<main dir>/{runtime,worktime,testtime}/index.js
- *
- * The location path extension is not specified to afford plugin author the
- * index dir style. This means the location path must be passed into a
- * node-module-resolution functino e.g. `require`. Do not pass it to a raw FS
- * file read function.
- */
-async function getDimensionEntrypointLocation(
-  dimensionkind: Dimension,
-  packageJson: ValidatedPackageJson,
-  plugin: Plugin
-): Promise<DimensionEntrypointLocation | null> {
-  if (plugin[dimensionkind]) return plugin[dimensionkind]!
-
-  const dimensionEntrypointPath = Path.join(getPackageJsonMain(packageJson), dimensionkind)
-  const conventionalPath = Path.join(Path.dirname(plugin.packageJsonPath), dimensionEntrypointPath)
-
-  if (await fs.existsAsync(conventionalPath)) {
-    return {
-      module: dimensionEntrypointPath,
-      export: 'plugin',
-    }
-  }
-
-  return null
-}
 
 /**
  * This gets all the plugins in use in the app.
@@ -128,15 +30,4 @@ export async function getUsedPlugins(layout: Layout.Layout): Promise<Plugin[]> {
       error: e,
     })
   }
-}
-
-// helpers
-
-function addErrorMessageContext(additionalMessage: string, error: Error): Error {
-  error.message = `${additionalMessage}\n\n${error.message}`
-  return error
-}
-
-function createGetManifestError(error: Error): Error {
-  return new Error(`An error occured whlie loading one of the plugins you are using.\n\n${error.message}`)
 }

--- a/src/lib/plugin/utils.ts
+++ b/src/lib/plugin/utils.ts
@@ -54,9 +54,9 @@ export async function getPluginManifest(plugin: Plugin): Promise<Manifest> {
   const validatedPackageJson = packageJson as ValidatedPackageJson
 
   const [worktime, runtime, testtime] = await Promise.all([
-    checkForConventionalDimensionEntrypoint('worktime', validatedPackageJson, plugin),
-    checkForConventionalDimensionEntrypoint('runtime', validatedPackageJson, plugin),
-    checkForConventionalDimensionEntrypoint('testtime', validatedPackageJson, plugin),
+    getDimensionEntrypointLocation('worktime', validatedPackageJson, plugin),
+    getDimensionEntrypointLocation('runtime', validatedPackageJson, plugin),
+    getDimensionEntrypointLocation('testtime', validatedPackageJson, plugin),
   ])
 
   return {
@@ -84,7 +84,7 @@ export async function getPluginManifest(plugin: Plugin): Promise<Manifest> {
  * node-module-resolution functino e.g. `require`. Do not pass it to a raw FS
  * file read function.
  */
-async function checkForConventionalDimensionEntrypoint(
+async function getDimensionEntrypointLocation(
   dimensionkind: Dimension,
   packageJson: ValidatedPackageJson,
   plugin: Plugin

--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -8,8 +8,12 @@ import { log } from '../nexus-logger'
  * Log a meaningful semantic error message sans stack track and then crash
  * the program with exit code 1. Parameters are a passthrough to `console.error`.
  */
-export function fatal(template: string, context?: Record<string, unknown>): never {
-  log.fatal(template, context)
+export function fatal(errOrMsg: string | Error, context?: Record<string, unknown>): never {
+  if (errOrMsg instanceof Error) {
+    log.fatal(errOrMsg.message, context)
+  } else {
+    log.fatal(errOrMsg, context)
+  }
   process.exit(1)
 }
 

--- a/src/lib/reflection/fork-script.ts
+++ b/src/lib/reflection/fork-script.ts
@@ -26,11 +26,12 @@ async function run() {
 
   if (isReflectionStage('typegen')) {
     try {
+      const plugins = await Plugin.importAndLoadRuntimePlugins(app.private.state.plugins)
       await writeArtifacts({
         graphqlSchema: app.private.state.assembled!.schema,
         layout,
         schemaSettings: app.settings.current.schema,
-        plugins: Plugin.importAndLoadRuntimePlugins(app.private.state.plugins),
+        plugins,
       })
       sendDataToParent({
         type: 'success-typegen',

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -34,7 +34,7 @@ export async function getNexusReport(layout: Layout): Promise<Report> {
     })
   )
   const pluginEntrypoints = await Plugin.getUsedPlugins(layout)
-  const pluginManifests = pluginEntrypoints.map(Plugin.entrypointToManifest)
+  const pluginManifests = await Promise.all(pluginEntrypoints.map(Plugin.getPluginManifest))
 
   return {
     node: process.version,

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -157,6 +157,7 @@ export function range(times: number): number[] {
 
 import * as Path from 'path'
 import Git from 'simple-git/promise'
+import { PackageJson } from 'type-fest'
 
 export type OmitFirstArg<Func> = Func extends (firstArg: any, ...args: infer Args) => infer Ret
   ? (...args: Args) => Ret
@@ -291,4 +292,16 @@ export function simpleDebounce<T extends (...args: any[]) => Promise<any>>(fn: T
 
 export type Index<T> = {
   [key: string]: T
+}
+
+/**
+ * An ESM-aware reading of the main entrypoint to a package.
+ */
+export function getPackageJsonMain(packageJson: PackageJson & { main: string }): string {
+  // todo when building for a bundler, we want to read from the esm paths. Otherwise the cjs paths.
+  //  - this condition takes a stab at the problem but is basically a stub.
+  //  - this todo only needs to be completed once we are actually trying to do esm tree-shaking (meaning, we've moved beyond node-file-trace)
+  return process.env.ESM && packageJson.module
+    ? Path.dirname(packageJson.module)
+    : Path.dirname(packageJson.main)
 }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -114,7 +114,7 @@ export function create(): App {
     settings: settingsComponent.public,
     schema: schemaComponent.public,
     server: serverComponent.public,
-    assemble() {
+    async assemble() {
       if (appState.assembled) return
 
       // todo https://github.com/graphql-nexus/nexus/pull/788#discussion_r420645846
@@ -122,7 +122,7 @@ export function create(): App {
 
       if (Reflection.isReflectionStage('plugin')) return
 
-      const loadedPlugins = Plugin.importAndLoadRuntimePlugins(appState.plugins)
+      const loadedPlugins = await Plugin.importAndLoadRuntimePlugins(appState.plugins)
       appState.assembled!.loadedPlugins = loadedPlugins
 
       const { schema, missingTypes } = schemaComponent.private.assemble(loadedPlugins)

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -118,7 +118,7 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
     },
   }
 
-  const testContextContributions = Plugin.importAndLoadTesttimePlugins(pluginManifests)
+  const testContextContributions = await Plugin.importAndLoadTesttimePlugins(pluginManifests)
 
   for (const testContextContribution of testContextContributions) {
     Lo.merge(testContextCore, testContextContribution)


### PR DESCRIPTION
This commit allows plugin authors to rely on convention over
configuration when writing their manifest inputs. If the plugin author
creates modules (or index dirs) called "runtime" "testtime" or "worktime" as peers to their plugin entrypoint then Nexus will find them automatically.

closes #858

Before:

```ts
import { PluginEntrypoint } from 'nexus/plugin'
import { Settings } from './settings'

export const prisma: PluginEntrypoint<Settings> = (settings) => ({
  settings,
  packageJsonPath: require.resolve('../package.json'),
  runtime: {
    module: require.resolve('./runtime'),
    export: 'plugin',
  },
  worktime: {
    module: require.resolve('./worktime'),
    export: 'plugin',
  },
  testtime: {
    module: require.resolve('./testtime'),
    export: 'plugin',
  },
})

export default prisma
```

After:

```ts
import { PluginEntrypoint } from 'nexus/plugin'
import { Settings } from './settings'

export const prisma: PluginEntrypoint<Settings> = (settings) => ({
  settings,
  packageJsonPath: require.resolve('../package.json'),
})

export default prisma
```

#### TODO

- [ ] docs
- [ ] tests