### PR TITLE
feat(testing): relocate server start/stop to app

### DIFF
--- a/docs/api/modules/main.md
+++ b/docs/api/modules/main.md
@@ -18,14 +18,12 @@ app.schema.queryType({
     t.field('foo', { type: 'String' })
   },
 })
-
-app.server.start()
 ```
 
 **Example of imporrting named exports**
 
 ```ts
-import { schema, server, settings, log } from 'nexus'
+import { schema, settings, log } from 'nexus'
 
 log.info('hello world')
 
@@ -40,6 +38,4 @@ schema.queryType({
     t.field('foo', { type: 'String' })
   },
 })
-
-server.start()
 ```

--- a/docs/api/modules/testing.md
+++ b/docs/api/modules/testing.md
@@ -12,21 +12,20 @@ This context can be augmented by plugins.
 function createTestContext(opts?: CreateTestContextOptions): Promise<TestContext>
 ```
 
-
 ##### Example With Jest
 
 ```ts
-import { } from 'nexus/testing'
+import { TestContext, createTestContext } from 'nexus/testing'
 
 let ctx: TestContext
 
 beforeAll(async () => {
-  ctx = await createTestContext()
-  await ctx.server.start()
+  Object.assign(ctx, await createTestContext())
+  await ctx.app.start()
 })
 
 afterAll(async () => {
-  await ctx.server.stop()
+  await ctx.app.stop()
 })
 
 test('hello', async () => {

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -24,11 +24,11 @@ export function createTestContext(): TestContext {
 
   beforeAll(async () => {
     Object.assign(ctx, await originalCreateTestContext())
-    await ctx.app.server.start()
+    await ctx.app.start()
   })
 
   afterAll(async () => {
-    await ctx.app.server.stop()
+    await ctx.app.stop()
   })
 
   return ctx

--- a/docs/references/recipes.md
+++ b/docs/references/recipes.md
@@ -201,12 +201,12 @@ If you don't want to use a docker, here are some links to alternative approaches
      let ctx: TestContext
 
      beforeAll(async () => {
-       ctx = await createTestContext()
-       await ctx.app.server.start()
+       Object.assign(ctx, await createTestContext())
+       await ctx.app.start()
      })
 
      afterAll(async () => {
-       await ctx.app.server.stop()
+       await ctx.app.stop()
      })
 
      return ctx

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -23,10 +23,8 @@ export function createAppClient(apiUrl: string): AppClient {
 
 export interface TestContextAppCore {
   query: AppClient['query']
-  server: {
-    start: () => Promise<void>
-    stop: () => Promise<void>
-  }
+  start: () => Promise<void>
+  stop: () => Promise<void>
 }
 
 export interface TestContextCore {
@@ -57,18 +55,18 @@ export interface CreateTestContextOptions {
  * @example
  *
  * With jest
- * ```
+ * ```ts
  * import { createTestContext, TestContext } from 'nexus/testing'
  *
  * let ctx: TestContext
  *
  * beforeAll(async () => {
- *  ctx = await createTestContext()
- *  await ctx.server.start()
+ *   ctx = await createTestContext()
+ *   await ctx.app.start()
  * })
  *
  * afterAll(async () => {
- *  await ctx.server.stop()
+ *   await ctx.app.stop()
  * })
  * ```
  */
@@ -114,10 +112,8 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
   const api: TestContextCore = {
     app: {
       query: appClient.query,
-      server: {
-        start: appRunner.start,
-        stop: appRunner.stop,
-      },
+      start: appRunner.start,
+      stop: appRunner.stop,
     },
   }
 


### PR DESCRIPTION
closes #857 

This aligns with changes to the server component api where `start`/`stop` are no longer methods. This is because the concept no longer made sense in a serverless context.

BREAKING CHANGE:

Before:

```ts
let ctx

beforeAll(async () => {
  Object.assign(ctx, await createTestContext())
  await ctx.app.server.start()
})
afterAll(async () => {
  await ctx.app.server.stop()
})
```

After:

```ts
let ctx

beforeAll(async () => {
  Object.assign(ctx, await createTestContext())
  await ctx.app.start()
})
afterAll(async () => {
  await ctx.app.stop()
})
```


#### TODO

- [x] docs
- [ ] tests