### PR TITLE
fix: testtime contribution typings

### DIFF
--- a/src/lib/plugin/index.spec.ts
+++ b/src/lib/plugin/index.spec.ts
@@ -1,8 +1,10 @@
+import { isLeft } from 'fp-ts/lib/Either'
 import * as Path from 'path'
 import * as TC from '../test-context'
 import { repalceInObject } from '../utils'
+import { importAndLoadTesttimePlugins } from './load'
 import { getPluginManifest } from './manifest'
-import { Plugin } from './types'
+import { Dimension, Plugin, PluginWithoutSettings } from './types'
 
 const ctx = TC.create(TC.tmpDir(), TC.fs())
 
@@ -88,5 +90,26 @@ describe('manifest', () => {
         },
       }
     `)
+  })
+})
+
+function stubPlugin(dimension: Dimension, exportName: string): [PluginWithoutSettings] {
+  return [
+    {
+      packageJsonPath: require.resolve('../../../package.json'),
+      [dimension]: {
+        module: require.resolve('./plugin.fixture.js'),
+        export: exportName,
+      },
+    },
+  ]
+}
+
+// TODO: figure out why it's process.exiting
+describe('plugin', () => {
+  it('fails if testtime contrib is not an object', () => {
+    const [result] = importAndLoadTesttimePlugins(stubPlugin('testtime', 'wrongTesttimePlugin'))
+
+    expect(isLeft(result)).toStrictEqual(true)
   })
 })

--- a/src/lib/plugin/index.spec.ts
+++ b/src/lib/plugin/index.spec.ts
@@ -113,7 +113,7 @@ describe('plugin', () => {
     if (isLeft(result)) {
       expect(result.left).toMatchInlineSnapshot(`
         [Error: Ignoring the testtime contribution from the Nexus plugin \`nexus\` because its contribution is not an object.
-                  This is likely to cause an error in your tests. Please reach out to the author of the plugin to fix the issue.]
+                This is likely to cause an error in your tests. Please reach out to the author of the plugin to fix the issue.]
       `)
     }
   })

--- a/src/lib/plugin/index.spec.ts
+++ b/src/lib/plugin/index.spec.ts
@@ -105,11 +105,16 @@ function stubPlugin(dimension: Dimension, exportName: string): [PluginWithoutSet
   ]
 }
 
-// TODO: figure out why it's process.exiting
 describe('plugin', () => {
   it('fails if testtime contrib is not an object', () => {
-    const [result] = importAndLoadTesttimePlugins(stubPlugin('testtime', 'wrongTesttimePlugin'))
+    const [result] = importAndLoadTesttimePlugins(stubPlugin('testtime', 'testtimeNotAnObject'))
 
-    expect(isLeft(result)).toStrictEqual(true)
+    expect(isLeft(result)).toBe(true)
+    if (isLeft(result)) {
+      expect(result.left).toMatchInlineSnapshot(`
+        [Error: Ignoring the testtime contribution from the Nexus plugin \`nexus\` because its contribution is not an object.
+                  This is likely to cause an error in your tests. Please reach out to the author of the plugin to fix the issue.]
+      `)
+    }
   })
 })

--- a/src/lib/plugin/load.ts
+++ b/src/lib/plugin/load.ts
@@ -1,11 +1,12 @@
+import { stripIndent } from 'common-tags'
+import * as Lo from 'lodash'
 import * as Layout from '../layout'
 import { rootLogger } from '../nexus-logger'
-import { partition, isObject } from '../utils'
+import { partition } from '../utils'
 import { importPluginDimension } from './import'
 import { createBaseLens, createRuntimeLens, createWorktimeLens } from './lens'
 import { getPluginManifests, showManifestErrorsAndExit } from './manifest'
 import { Plugin } from './types'
-import { stripIndent } from 'common-tags'
 
 const log = rootLogger.child('plugin')
 
@@ -85,7 +86,7 @@ export function importAndLoadTesttimePlugins(plugins: Plugin[]) {
       log.trace('loading testtime plugin', { name: plugin.manifest.name })
       const contribution = plugin.run(createBaseLens(plugin.manifest.name))
 
-      if (!isObject(contribution)) {
+      if (!Lo.isPlainObject(contribution)) {
         /**
          * We do not `fatal` here because performing a `process.exit` causes Jest to not display the logging
          */

--- a/src/lib/plugin/plugin.fixture.js
+++ b/src/lib/plugin/plugin.fixture.js
@@ -1,9 +1,3 @@
-export const correctTesttimePlugin = () => () => {
-  return {
-    foo: 'bar'
-  }
-}
-
-export const wrongTesttimePlugin = () => () => {
+module.exports.testtimeNotAnObject = () => () => {
   return []
 }

--- a/src/lib/plugin/plugin.fixture.js
+++ b/src/lib/plugin/plugin.fixture.js
@@ -1,0 +1,9 @@
+export const correctTesttimePlugin = () => () => {
+  return {
+    foo: 'bar'
+  }
+}
+
+export const wrongTesttimePlugin = () => () => {
+  return []
+}

--- a/src/lib/plugin/types/lens.ts
+++ b/src/lib/plugin/types/lens.ts
@@ -133,7 +133,7 @@ export type RuntimeContributions<C extends {} = any> = {
   }
 }
 
-export type TesttimeContributions = Utils.DeepPartial<Testing.TestContextCore> & { [prop: string]: any }
+export type TesttimeContributions = Utils.DeepPartial<Testing.TestContextCore, true>
 
 export type Lens = {
   log: Logger.Logger

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,7 @@
+import * as Path from 'path'
+import Git from 'simple-git/promise'
+import { JsonObject, PackageJson, Primitive } from 'type-fest'
+
 export type MaybePromise<T = void> = T | Promise<T>
 
 export type CallbackRegistrer<F> = (f: F) => void
@@ -7,7 +11,14 @@ export type SideEffector = () => MaybePromise
 export type Param1<F> = F extends (p: infer P, ...args: any[]) => any ? P : never
 
 /**
- * DeepPartial - borrowed from `utility-types`
+ * Represents a POJO. Prevents from allowing arrays and functions
+ */
+export type StrictObject = {
+  [x: string]: Primitive | object
+}
+
+/**
+ * DeepPartial - modified version from `utility-types`
  * @desc Partial that works for deeply nested structure
  * @example
  *   Expect: {
@@ -26,18 +37,22 @@ export type Param1<F> = F extends (p: infer P, ...args: any[]) => any ? P : neve
  *   };
  *   type PartialNestedProps = DeepPartial<NestedProps>;
  */
-export declare type DeepPartial<T> = T extends Function
+export type DeepPartial<T, AllowAdditionalProps extends boolean = false> = T extends Function
   ? T
   : T extends Array<infer U>
   ? DeepPartialArray<U>
   : T extends object
-  ? DeepPartialObject<T>
+  ? AllowAdditionalProps extends true
+    ? DeepPartialObject<T, true> & StrictObject
+    : DeepPartialObject<T, false>
   : T | undefined
-/** @private */
+
 export interface DeepPartialArray<T> extends Array<DeepPartial<T>> {}
-/** @private */
-export declare type DeepPartialObject<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>
+
+export type DeepPartialObject<T extends object, AllowAdditionalProps extends boolean = false> = {
+  [P in keyof T]?: AllowAdditionalProps extends true
+    ? DeepPartial<T[P], true> & StrictObject
+    : DeepPartial<T[P], false>
 }
 
 /**
@@ -67,9 +82,9 @@ export declare type DeepRequired<T> = T extends (...args: any[]) => any
   : T extends object
   ? DeepRequiredObject<T>
   : T
-/** @private */
+
 export interface DeepRequiredArray<T> extends Array<DeepRequired<NonUndefined<T>>> {}
-/** @private */
+
 export declare type DeepRequiredObject<T> = {
   [P in keyof T]-?: DeepRequired<NonUndefined<T[P]>>
 }
@@ -154,10 +169,6 @@ export function range(times: number): number[] {
   }
   return list
 }
-
-import * as Path from 'path'
-import Git from 'simple-git/promise'
-import { JsonObject, PackageJson } from 'type-fest'
 
 export type OmitFirstArg<Func> = Func extends (firstArg: any, ...args: infer Args) => infer Ret
   ? (...args: Args) => Ret

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -13,7 +13,7 @@ export type Param1<F> = F extends (p: infer P, ...args: any[]) => any ? P : neve
 /**
  * Represents a POJO. Prevents from allowing arrays and functions
  */
-export type StrictObject = {
+export type PlainObject = {
   [x: string]: Primitive | object
 }
 
@@ -43,7 +43,7 @@ export type DeepPartial<T, AllowAdditionalProps extends boolean = false> = T ext
   ? DeepPartialArray<U>
   : T extends object
   ? AllowAdditionalProps extends true
-    ? DeepPartialObject<T, true> & StrictObject
+    ? DeepPartialObject<T, true> & PlainObject
     : DeepPartialObject<T, false>
   : T | undefined
 
@@ -51,7 +51,7 @@ export interface DeepPartialArray<T> extends Array<DeepPartial<T>> {}
 
 export type DeepPartialObject<T extends object, AllowAdditionalProps extends boolean = false> = {
   [P in keyof T]?: AllowAdditionalProps extends true
-    ? DeepPartial<T[P], true> & StrictObject
+    ? DeepPartial<T[P], true> & PlainObject
     : DeepPartial<T[P], false>
 }
 
@@ -389,8 +389,4 @@ export function deserializeError(se: SerializedError): Error {
   Object.assign(e, rest)
 
   return e
-}
-
-export function isObject(o: any) {
-  return o !== null && typeof o === 'object' && Array.isArray(o) === false
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -390,3 +390,7 @@ export function deserializeError(se: SerializedError): Error {
 
   return e
 }
+
+export function isObject(o: any) {
+  return o !== null && typeof o === 'object' && Array.isArray(o) === false
+}

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -121,6 +121,10 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
   const testContextContributions = PluginRuntime.importAndLoadTesttimePlugins(pluginManifests)
 
   for (const testContextContribution of testContextContributions) {
+    if (testContextContribution === null) {
+      continue
+    }
+
     Lo.merge(api, testContextContribution)
   }
 

--- a/src/runtime/testing.ts
+++ b/src/runtime/testing.ts
@@ -1,3 +1,4 @@
+import { isLeft } from 'fp-ts/lib/Either'
 import getPort from 'get-port'
 import * as Lo from 'lodash'
 import app from '.'
@@ -7,6 +8,9 @@ import * as PluginRuntime from '../lib/plugin'
 import * as PluginWorktime from '../lib/plugin/worktime'
 import { PrivateApp } from './app'
 import { createDevAppRunner } from './start'
+import { rootLogger } from '../lib/nexus-logger'
+
+const pluginLogger = rootLogger.child('plugin')
 
 type AppClient = {
   query: GraphQLClient['request']
@@ -121,11 +125,12 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
   const testContextContributions = PluginRuntime.importAndLoadTesttimePlugins(pluginManifests)
 
   for (const testContextContribution of testContextContributions) {
-    if (testContextContribution === null) {
+    if (isLeft(testContextContribution)) {
+      pluginLogger.error(testContextContribution.left.message, { error: testContextContribution.left })
       continue
     }
 
-    Lo.merge(api, testContextContribution)
+    Lo.merge(api, testContextContribution.right)
   }
 
   return api as TestContext


### PR DESCRIPTION
This PR fixes too permissive typings that were used to type the plugin testtime contributions and guards against contribution that would not be objects.

It's related to https://github.com/graphql-nexus/nexus-plugin-prisma/pull/125