### PR TITLE
chore(docs): fix link

### DIFF
--- a/docs/components/logger/api.md
+++ b/docs/components/logger/api.md
@@ -1,3 +1,3 @@
 # API
 
-Please refer to the [framework logger component API docs](http://localhost:3000/#/api/modules/main/exports/logger).
+Please refer to the [framework logger component API docs](api/modules/main/exports/logger).


### PR DESCRIPTION
Removed hardcoded hostname from the absolute url.

closes #...

#### TODO

- [ ] docs
- [ ] tests
