### PR TITLE
feat(tslsp): exclude autocompletions from private api

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,9 +45,12 @@ Nexus is a delightful framework for building GraphQL APIs in Node. It leverages 
   - One dep
   - Add prisma, only one dep more
   - Nexus handles sound integration between all components
+  - Nexus handles minimal deployment size via integrated tree-shake step in build
 - Decomposable, from framework to libs
   - @nexus/schema
   - @nexus/logger
+- Enhanced IDE Experience via TypeScript Language Service Plugin
+  - Refined nexus lib autocomplete
 
 ### Future Features
 

--- a/docs/guides/project-layout.md
+++ b/docs/guides/project-layout.md
@@ -28,6 +28,18 @@
 
 if `compilerOptions.noEmit` is set to `true` then Nexus will not output the build. This makes `nexus build` effectively a checker. This option usually [represents user error](https://github.com/graphql-nexus/nexus/issues/702) so by default Nexus will warn when this option is used. In the future ([#800](https://github.com/graphql-nexus/nexus/issues/800)) there will be ways to disable this the warning if it is really your intent.
 
+##### TypeScript Language Service Plugin
+
+Nexus ships with a TypeScript Language Service Plugin. It currently helps with improved autocomplete experience. In the future it will do more. Nexus will check that you are using it correctly in dev mode. You can see an example of its effect below.
+
+Autocomplete without Nexus TS LSP:
+
+![](https://user-images.githubusercontent.com/284476/82776800-1bbe0e00-9e1a-11ea-83a1-eb175b11a2ca.png)
+
+Autocomplete with Nexus TS LSP:
+
+![](https://user-images.githubusercontent.com/284476/82776802-1cef3b00-9e1a-11ea-88c3-065869407380.png)
+
 ## Conventions
 
 Nexus imposes a few requirements about how you structure your codebase.
@@ -44,7 +56,7 @@ Nexus looks for modules that import `nexus` and uses codegen to statically impor
 
 Beware if you have module-level side-effects coming from something else than Nexus, as these side-effects will always be run when your app starts.
 
-> *Note: `require` is not supported.
+> \*Note: `require` is not supported.
 
 ### Entrypoint
 

--- a/scripts/build-module-facades.js
+++ b/scripts/build-module-facades.js
@@ -37,6 +37,8 @@ const facades = [
   ['components/logger.d.ts',  "export * from '../dist/components/logger'"             + os.EOL],
   ['components/logger.js',    "module.exports = require('../dist/components/logger')" + os.EOL],
 
+  ['typescript-language-service/index.d.ts',  "export * from './dist/typescript-language-service'"             + os.EOL],
+  ['typescript-language-service/index.js',    "module.exports = require('./dist/typescript-language-service')" + os.EOL],
 ]
 
 // Write facade files

--- a/src/typescript-language-service/index.ts
+++ b/src/typescript-language-service/index.ts
@@ -1,0 +1,84 @@
+import { inspect } from 'util'
+
+type Modules = {
+  typescript: typeof import('typescript/lib/tsserverlibrary')
+}
+
+module.exports = function init(modules: Modules) {
+  function create(info: ts.server.PluginCreateInfo) {
+    function log(...x: any[]) {
+      return info.project.log('nexus: ' + x.join(' | '))
+    }
+
+    function dump(...x: any[]) {
+      return x.map(i).map((x) => info.project.log('nexus: ' + x))
+    }
+
+    log('creating')
+
+    // Set up decorator
+    const proxy = Object.create(null) as ts.LanguageService
+    for (let k of Object.keys(info.languageService) as Array<keyof ts.LanguageService>) {
+      const x: any = info.languageService[k]
+      proxy[k] = ((...args: {}[]) => x.apply(info.languageService, args)) as any
+    }
+
+    proxy.getCompletionsAtPosition = (fileName, position, options) => {
+      const prior = info.languageService.getCompletionsAtPosition(fileName, position, options)
+
+      if (!prior) return prior
+
+      log(prior.entries.length, fileName, position)
+
+      /**
+       * Filter out entries from nexus lib.
+       *
+       * For example "log" has "importAndLoadRuntimePlugins" among completions.
+       */
+      prior.entries = prior.entries.filter((c) => {
+        if (!c.source) return true
+        const match = c.source.match(/.*\/nexus\/(.+)$/)
+        if (!match) return true
+        log('found completion')
+        const publicAPI =
+          match[1].includes('dist/index') ||
+          match[1].includes('dist/runtime/index') ||
+          match[1].includes('dist/testtime/index')
+        if (!publicAPI) {
+          log('dropping completion because not public api')
+          dump(c)
+        }
+        return publicAPI
+      })
+
+      /**
+       * Boost value of nexus runtime exports
+       * todo so far this appears to do nothing actually
+       */
+      prior.entries.forEach((c) => {
+        if (c.source?.match(/.*\/nexus\/dist\/runtime\/index/)) {
+          c.isRecommended = true
+        }
+      })
+
+      return prior
+    }
+
+    return proxy
+  }
+
+  return {
+    create,
+  }
+}
+
+/**
+ * Helpers
+ */
+
+/**
+ * Inspect value
+ */
+function i(x: any) {
+  return inspect(x, { depth: 10, maxArrayLength: 1000 })
+}


### PR DESCRIPTION
This change introduces a TypeScript Langauge Service.

It needs to be used in the tsconfig like so:

```js
{
  "compilerOptions": {
    "plugins": [{ "name": "nexus/typescript-language-service" }]
  },
}
```

Nexus will automate management of this config, ensuring:

1. If present, that it is correctly configured
2. If not present, added

Before / After this change:

- Server

	<img width="980" alt="server-before" src="https://user-images.githubusercontent.com/284476/82776826-3abca000-9e1a-11ea-8ffb-180d4a3bde3c.png">

	<img width="955" alt="server-after" src="https://user-images.githubusercontent.com/284476/82776830-3db79080-9e1a-11ea-9870-75ae6f1cf74c.png">



- Settings

	<img width="954" alt="settings-before" src="https://user-images.githubusercontent.com/284476/82776800-1bbe0e00-9e1a-11ea-83a1-eb175b11a2ca.png">

	<img width="985" alt="settings-after" src="https://user-images.githubusercontent.com/284476/82776802-1cef3b00-9e1a-11ea-88c3-065869407380.png">

- log

	![log-before](https://user-images.githubusercontent.com/284476/82776862-532cba80-9e1a-11ea-9db5-2c01ced5759c.png)

	![log-after](https://user-images.githubusercontent.com/284476/82776852-4f993380-9e1a-11ea-8d0a-af355c0a6cd9.png)





closes #...

#### TODO

- [x] docs
- [x] ~tests~ in the future, see comment below.
- [x] tsconfig automation