### PR TITLE
docs: jsdoc links to website in runtime exports

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -9,7 +9,8 @@
 
 - [Concepts](guides/concepts)
 - [Schema](guides/schema)
-- [Serverless](guides/serverless)
+- [Server](guides/server)
+- [Logger](guides/logger)
 - [Testing](guides/testing)
 - [Project Layout](guides/project-layout)
 - [Error Handling](guides/error-handling)

--- a/docs/api/modules/main/exports/logger.md
+++ b/docs/api/modules/main/exports/logger.md
@@ -1,14 +1,6 @@
 # `import { log }`
 
-[issues](https://github.com/graphql-nexus/nexus/labels/scope%2Flogger) - [`feature`](https://github.com/graphql-nexus/nexus/issues?q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Ffeat) [`bug`](https://github.com/graphql-nexus/nexus/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Fbug+)
-
-Use the logger to output structured information about runtime activity.
-
-Logging is one of the primary means for knowing what is going on at runtime, what data is flowing through, and how so. It is a classic workhorse of debugging and development time feedback. There are a wealth of specialized tools but a great logging strategy can take you far. Nexus gives you a logging system built for a modern cloud native environment.
-
-Your app should only output logs via Nexus Logger. This ensures that you maintain log level control and are always working with JSON. We work hard to make the logger so good that you'll to use it.
-
-All logs are sent to stdout (not stderr). Logs are formatted as JSON but there is a pretty mode designed for development.
+[issues](https://nxs.li/issues/component/logger) / [features](https://nxs.li/issues/components/logger/features) | [bugs](https://nxs.li/issues/component/logger/bugs)
 
 ### `fatal`
 
@@ -102,14 +94,6 @@ foo.info('foo')
 // { "context": { "user": "Toto", "bar": "bar"  }, path: ["app", "bar"], "event": "bar", ... }
 // { "context": { "user": "Toto", "foo": "foo"  }, path: ["app", "foo"], "event": "foo", ... }
 ```
-
-##### Remarks
-
-You can create child loggers recursively starting from the root logger. A child logger extends their parent's component path and inherits their parent's context. Children can add context that is visible to themselves and their descedents.
-
-Child loggers are useful when you want to pass a logger to something that should be tracked as its own subsystem and/or may add context that you want isolated from the rest of the system. For example a classic use-case is the logger-instance-per-request pattern where a request-scoped logger is used for all logs in a request-response code path. This makes it much easier in production to group logs in your logging platform by request-response lifecycles.
-
-All runtime logs in your app (including from plugins come from either the `logger` itself or descendents thereof. This means if you wish absolutely every log being emitted by your app to contain some additional context you can do so simply by adding context to the root logger.
 
 ### Type Glossary
 

--- a/docs/api/modules/main/exports/schema.md
+++ b/docs/api/modules/main/exports/schema.md
@@ -1,6 +1,6 @@
 # `import { schema }`
 
-[issues](https://github.com/graphql-nexus/nexus/labels/scope%2Fschema) - [`features`](https://github.com/graphql-nexus/nexus/issues?q=is%3Aopen+label%3Ascope%2Fschema+label%3Atype%2Ffeat) [`bugs`](https://github.com/graphql-nexus/nexus/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fschema+label%3Atype%2Fbug+)
+[issues](https://nxs.li/issues/component/schema) / [features](https://nxs.li/issues/components/schema/features) | [bugs](https://nxs.li/issues/component/schema/bugs)
 
 Use the schema to model your domain, all the data that your API will accept and return, and how all the various objects in the domain relate to one another (the "graph" in "GraphQL").
 
@@ -1075,9 +1075,9 @@ When passing a `GraphQLScalarType`, you can additionally pass a `methodName` as 
 ```ts
 import { schema } from 'nexus'
 import { GraphQLDate } from 'graphql-iso-date'
-     
+
 schema.importType(GraphQLDate, 'date')
-     
+
 schema.objectType({
   name: 'SomeObject',
   definition(t) {
@@ -1093,7 +1093,6 @@ schema.objectType({
 ```ts
 import { schema } from 'nexus'
 import { existingSchema } from './existing-schema'
-
 
 Object.values(existingSchema.getTypeMap()).forEach(schema.importType)
 ```

--- a/docs/api/modules/main/exports/server.md
+++ b/docs/api/modules/main/exports/server.md
@@ -1,6 +1,6 @@
 # `import { server }`
 
-[issues](https://github.com/graphql-nexus/nexus/labels/scope%2Fserver) - [`feature`](https://github.com/graphql-nexus/nexus/issues?q=is%3Aopen+label%3Ascope%2Fserver+label%3Atype%2Ffeat) [`bug`](https://github.com/graphql-nexus/nexus/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fserver+label%3Atype%2Fbug+)
+[issues](https://nxs.li/issues/component/server) / [features](https://nxs.li/issues/components/server/features) | [bugs](https://nxs.li/issues/component/server/bugs)
 
 Use the server to run the HTTP server that clients will connect to.
 

--- a/docs/api/modules/main/exports/use.md
+++ b/docs/api/modules/main/exports/use.md
@@ -1,6 +1,6 @@
 # `import { use }`
 
-[issues](https://github.com/graphql-nexus/nexus/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ascope%2Fplugins) – [features](https://github.com/graphql-nexus/nexus/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ascope%2Fplugins+label%3Atype%2Ffeat) ⬝ [bugs](https://github.com/graphql-nexus/nexus/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ascope%2Fplugins+label%3Atype%2Fbug)
+[issues](https://nxs.li/issues/component/plugins) / [features](https://nxs.li/issues/components/plugins/features) | [bugs](https://nxs.li/issues/component/plugins/bugs)
 
 Use the plugin component to add new functionality to your project.
 

--- a/docs/components/schema/api/_sidebar.md
+++ b/docs/components/schema/api/_sidebar.md
@@ -4,17 +4,17 @@
 - [Onboarding](getting-started/onboarding)
 - [Tutorial](getting-started/tutorial)
 - [Migrate from Nexus Schema](getting-started/migrate-from-nexus-schema)
-- [Changelog](changelog)
 
 - Guides
 
 - [Concepts](guides/concepts)
 - [Schema](guides/schema)
+- [Server](guides/server)
+- [Logger](guides/logger)
 - [Testing](guides/testing)
 - [Project Layout](guides/project-layout)
 - [Error Handling](guides/error-handling)
 - [Plugins](guides/plugins)
-- [Debugging](guides/debugging)
 - [Recipes](references/recipes)
 - [Writing Plugins](guides/writing-plugins)
 - [CLI](guides/cli)

--- a/docs/guides/logger.md
+++ b/docs/guides/logger.md
@@ -1,0 +1,32 @@
+[API Reference](/api/modules/main/exports/logger) ⌁ [issues](https://nxs.li/issues/component/logger) / [features](https://nxs.li/issues/components/logger/features) | [bugs](https://nxs.li/issues/component/logger/bugs)
+
+Use the logger to output structured information about runtime activity.
+
+Logging is one of the primary means for knowing what is going on at runtime, what data is flowing through, and how so. It is a classic workhorse of debugging and development time feedback. There are a wealth of specialized tools but a great logging strategy can take you far. Nexus gives you a logging system built for a modern cloud native environment.
+
+Your app should only output logs via Nexus Logger. This ensures that you maintain log level control and are always working with JSON. We work hard to make the logger so good that you'll to use it.
+
+All logs are sent to stdout (not stderr). Logs are formatted as JSON but there is a pretty mode designed for development.
+
+## Child Loggers
+
+```ts
+log.addToContext({ user: 'Toto' })
+
+const bar = log.child('bar').addToContext({ bar: 'bar' })
+const foo = log.child('foo').addToContext({ foo: 'foo' })
+
+log.info('hello')
+bar.info('bar')
+foo.info('foo')
+
+// { "context": { "user": "Toto"  }, path: ["app"], "event": "hello", ... }
+// { "context": { "user": "Toto", "bar": "bar"  }, path: ["app", "bar"], "event": "bar", ... }
+// { "context": { "user": "Toto", "foo": "foo"  }, path: ["app", "foo"], "event": "foo", ... }
+```
+
+You can create child loggers recursively starting from the root logger. A child logger extends their parent's component path and inherits their parent's context. Children can add context that is visible to themselves and their descedents.
+
+Child loggers are useful when you want to pass a logger to something that should be tracked as its own subsystem and/or may add context that you want isolated from the rest of the system. For example a classic use-case is the logger-instance-per-request pattern where a request-scoped logger is used for all logs in a request-response code path. This makes it much easier in production to group logs in your logging platform by request-response lifecycles.
+
+All runtime logs in your app (including from plugins come from either the `logger` itself or descendents thereof. This means if you wish absolutely every log being emitted by your app to contain some additional context you can do so simply by adding context to the root logger.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,1 +1,3 @@
+[API Reference](/api/modules/main/exports/use) ⌁ [issues](https://nxs.li/issues/component/plugins) / [features](https://nxs.li/issues/components/plugins/features) | [bugs](https://nxs.li/issues/component/plugins/bugs)
+
 todo

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -1,6 +1,6 @@
 # Schema
 
-[issues](https://github.com/graphql-nexus/nexus/labels/scope%2Fschema) – [features](https://github.com/graphql-nexus/nexus/issues?q=is%3Aopen+label%3Ascope%2Fschema+label%3Atype%2Ffeat) ⬝ [bugs](https://github.com/graphql-nexus/nexus/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fschema+label%3Atype%2Fbug+)
+[API Reference](/api/modules/main/exports/schema) ⌁ [issues](https://nxs.li/issues/component/schema) / [features](https://nxs.li/issues/components/schema/features) | [bugs](https://nxs.li/issues/component/schema/bugs)
 
 This is the Nexus schema component guide. Here you will find concepts explained and a survey of how to use the API. If you are not familiar with Nexus this is a good document to read. If you are familiar, then the [Schema API Docs](/api/modules/main/exports/schema) may be of more use to you.
 
@@ -312,7 +312,7 @@ When creating an API, especially before going to production or lifting features 
 
 If inputs are optional or outputs are guaranteed then client developers will have a simpler API to deal with since making requests demands no up front configuration and handling responses presents no null cases. On the other hand, for the API developer, changing the API becomes harder since turning inputs from optional to required or making outputs go from guaranteed to nullable are breaking changes from the client's point of view.
 
-Also, as more outputs are guaranteed, the greater the potential of the "null blast radius" can be. This is the effect where, within a server rutime, a `null` or error received from some data source where the schema states there shall be no `null` requires propagating the `null` up the data tree until a nullable type is found (or, at root, finally error).
+Also, as more outputs are guaranteed, the greater the potential of the "null blast radius" can be. This is the effect where, within a schema rutime, a `null` or error received from some data source where the schema states there shall be no `null` requires propagating the `null` up the data tree until a nullable type is found (or, at root, finally error).
 
 If you'd like to see these design considerations discussed further here are a few articles/resources you may find helpful:
 

--- a/docs/guides/server.md
+++ b/docs/guides/server.md
@@ -1,3 +1,7 @@
+[API Reference](/api/modules/main/exports/server) ⌁ [issues](https://nxs.li/issues/component/server) / [features](https://nxs.li/issues/components/server/features) | [bugs](https://nxs.li/issues/component/server/bugs)
+
+## Serverless
+
 - Nexus has experimental support for serverless deployments.
 - Support for serverless is being tracked in [#782](https://github.com/graphql-nexus/nexus/issues/782).
 - Serverless features are not yet documented in the API docs.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "components/schema.d.ts",
     "components/schema.js",
     "components/logger.d.ts",
-    "components/logger.js"
+    "components/logger.js",
+    "typescript-language-service/index.d.ts",
+    "typescript-language-service/index.js"
   ],
   "bin": {
     "nexus": "dist/cli/main.js"

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -13,37 +13,36 @@ import { assertAppNotAssembled } from './utils'
 
 const log = Logger.log.child('app')
 
-// todo the jsdoc below is lost on the destructured object exports later on...
+// WARNING Make sure that jsdoc edits here are ported to runtime/index
+
 export interface App {
   /**
-   * [API Reference](https://www.nexusjs.org/#/api/modules/main/exports/logger)  ⌁  [Guide](todo)
-   *
-   * ### todo
+   * [API Reference](https://nxs.li/docs/api/logger) ⌁ [Guide](https://nxs.li/docs/guides/logger) ⌁ [Issues](https://nxs.li/issues/components/logger)
    */
   log: Logger.Logger
   /**
-   * [API Reference](https://www.nexusjs.org/#/api/modules/main/exports/server)  ⌁  [Guide](todo)
-   *
-   * ### todo
-   *
+   * [API Reference](https://nxs.li/docs/api/server) ⌁ [Guide](https://nxs.li/docs/guides/server) ⌁ [Issues](https://nxs.li/issues/components/server)
    */
   server: Server.Server
   /**
-   * todo
-   */
-  settings: Settings.Settings
-  /**
-   * [API Reference](https://www.nexusjs.org/#/api/modules/main/exports/schema) // [Guide](todo)
-   *
-   * ### todo
+   * [API Reference](https://nxs.li/docs/api/schema) ⌁ [Guide](https://nxs.li/docs/guides/schema) ⌁ [Issues](https://nxs.li/issues/components/schema)
    */
   schema: Schema.Schema
   /**
-   * todo
+   * [API Reference](https://nxs.li/docs/api/settings) ⌁ [Issues](https://nxs.li/issues/components/settings)
+   */
+  settings: Settings.Settings
+  /**
+   * [API Reference](https://nxs.li/docs/api/use-plugins) ⌁ [Issues](https://nxs.li/issues/components/plugins)
    */
   use(plugin: Plugin.Plugin): void
   /**
-   * todo
+   * Run this to gather the final state of all Nexus api interactions. This method
+   * is experimental. It provides experimental support for Nextjs integration.
+   *
+   * In a regular Nexus app, you should not need to use this method.
+   *
+   * @experimental
    */
   assemble(): any
   /**

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -4,17 +4,37 @@ const app = App.create()
 
 export default app
 
-// Destructure app for export
-// Do not use destructuring syntax
-// Breaks jsdoc, only first destructed member annotated
-// todo jsdoc
+/**
+ * Destructure the app for named-export access. This is sugar, and to help
+ * auto-import workflows. Not everything on `app` is name-exported. Just those
+ * things that are part of every-day work.
+ *
+ * WARNING Do not use destructuring syntax here, it will not be jsdocable.
+ *
+ * WARNING Make sure that jsdoc edits here are ported to runtime/app
+ */
 
+/**
+ * [API Reference](https://nxs.li/docs/api/logger) ⌁ [Guide](https://nxs.li/docs/guides/logger) ⌁ [Issues](https://nxs.li/issues/components/logger)
+ */
 export const log = app.log
 
-export const schema = app.schema
-
+/**
+ * [API Reference](https://nxs.li/docs/api/server) ⌁ [Guide](https://nxs.li/docs/guides/server) ⌁ [Issues](https://nxs.li/issues/components/server)
+ */
 export const server = app.server
 
+/**
+ * [API Reference](https://nxs.li/docs/api/schema) ⌁ [Guide](https://nxs.li/docs/guides/schema) ⌁ [Issues](https://nxs.li/issues/components/schema)
+ */
+export const schema = app.schema
+
+/**
+ * [API Reference](https://nxs.li/docs/api/settings) ⌁ [Issues](https://nxs.li/issues/components/settings)
+ */
 export const settings = app.settings
 
+/**
+ * [API Reference](https://nxs.li/docs/api/use-plugins) ⌁ [Issues](https://nxs.li/issues/components/plugins)
+ */
 export const use = app.use

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,5 +1,8 @@
 import * as App from './app'
 
+/**
+ * [API Reference](https://nxs.li/docs/api/app) ⌁ [Issues](https://nxs.li/issues) ⌁ [Discussions](https://nxs.li/discussions) ⌁ [Tweets](https://nxs.li/tweets)
+ */
 const app = App.create()
 
 export default app

--- a/typescript-language-service/index.d.ts
+++ b/typescript-language-service/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/typescript-language-service'

--- a/typescript-language-service/index.js
+++ b/typescript-language-service/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/typescript-language-service')


### PR DESCRIPTION
- New nxs.li links have been created for:
	- component api docs
	- component guides
	- component issues
- These have been used in the website docs and in jsDoc
- jsDoc is added for the following:
	- all named exports
	- app default export
	- all components of `app` (copy of what is on named exports)
- It is intentional that the jsDoc only contains links right now now. We should figure out if we can add a simple string replace build step to inline content that is shared between website and jsDoc, and between jsDoc nodes.
- A logger guide section is started based on existing content in the api doc that was heavy on discussion.
- There is no guide content for settings yet so no link for that.
- Examples:

<img width="810" alt="Screen Shot 2020-05-26 at 3 12 19 PM" src="https://user-images.githubusercontent.com/284476/82942955-d0654600-9f66-11ea-8c7e-6ee3eca62236.png">
<img width="811" alt="Screen Shot 2020-05-26 at 3 13 21 PM" src="https://user-images.githubusercontent.com/284476/82942959-d0fddc80-9f66-11ea-8e8c-b576f3f9fed6.png">
<img width="808" alt="Screen Shot 2020-05-26 at 3 12 48 PM" src="https://user-images.githubusercontent.com/284476/82942961-d0fddc80-9f66-11ea-972e-49bb5b20fa41.png">
<img width="810" alt="Screen Shot 2020-05-26 at 3 14 12 PM" src="https://user-images.githubusercontent.com/284476/82942962-d0fddc80-9f66-11ea-9f7a-d170f1240399.png">
<img width="813" alt="Screen Shot 2020-05-26 at 3 28 26 PM" src="https://user-images.githubusercontent.com/284476/82942963-d1967300-9f66-11ea-965c-90c161eb8200.png">