### PR TITLE
fix(build): heroku/vercel deploy targets

### DIFF
--- a/src/lib/build/build.ts
+++ b/src/lib/build/build.ts
@@ -2,7 +2,7 @@ import { stripIndent } from 'common-tags'
 import * as FS from 'fs-jetpack'
 import * as Path from 'path'
 import * as Layout from '../../lib/layout'
-import { emitTSProgram, createTSProgram, deleteTSIncrementalFile } from '../../lib/tsc'
+import { createTSProgram, deleteTSIncrementalFile, emitTSProgram } from '../../lib/tsc'
 import {
   createStartModuleContent,
   prepareStartModule,
@@ -12,13 +12,13 @@ import { rootLogger } from '../nexus-logger'
 import * as Plugin from '../plugin'
 import { fatal } from '../process'
 import * as Reflection from '../reflection'
+import { bundle } from './bundle'
 import {
   computeBuildOutputFromTarget,
   logTargetPostBuildMessage,
   normalizeTarget,
   validateTarget,
 } from './deploy-target'
-import { bundle } from './bundle'
 
 const log = rootLogger.child('build')
 

--- a/src/lib/build/bundle.spec.ts
+++ b/src/lib/build/bundle.spec.ts
@@ -61,3 +61,9 @@ export function isModuleBundled(
 
   return { reason: path.reverse() }
 }
+
+describe('deployment=heroku', () => {
+  it.todo('checks that the start script points to the build output (bundle true)')
+  it.todo('checks that the start script points to the build output (bundle false)')
+  it.todo('checks that the package engines field is correctly set')
+})

--- a/src/lib/layout/layout.ts
+++ b/src/lib/layout/layout.ts
@@ -2,6 +2,7 @@ import Chalk from 'chalk'
 import { stripIndent } from 'common-tags'
 import * as FS from 'fs-jetpack'
 import * as Path from 'path'
+import * as ts from 'ts-morph'
 import { PackageJson } from 'type-fest'
 import type { ParsedCommandLine } from 'typescript'
 import { findFile, findFileRecurisvelyUpwardSync } from '../../lib/fs'
@@ -10,7 +11,6 @@ import { rootLogger } from '../nexus-logger'
 import * as PackageManager from '../package-manager'
 import { fatal } from '../process'
 import { readOrScaffoldTsconfig } from './tsconfig'
-import * as ts from 'ts-morph'
 
 export const DEFAULT_BUILD_FOLDER_PATH_RELATIVE_TO_PROJECT_ROOT = '.nexus/build'
 /**
@@ -80,6 +80,50 @@ type OutputInfo = {
   startModuleInPath: string
   tsOutputDir: string
   bundleOutputDir: string | null
+  /**
+   * The final path to the start module. When bundling disbaled, same as `startModuleOutPath`.
+   */
+  startModule: string
+  /**
+   * The final output dir. If bundler is enabled then this is `bundleOutputDir`.
+   * Otherwise it is `tsOutputDir`.
+   *
+   * When bundle case, this accounts for the bundle environment, which makes it
+   * **DIFFERENT** than the source root. For example:
+   *
+   * ```
+   * <out_root>/node_modules/
+   * <out_root>/api/app.ts
+   * <out_root>/api/index.ts
+   * ```
+   */
+  root: string
+  /**
+   * If bundler is enabled then the final output dir where the **source** is
+   * located. Otherwise same as `tsOutputDir`.
+   *
+   * When bundle case, this is different than `root` because it tells you where
+   * the source starts, not the build environment.
+   *
+   * For example, here `source_root` is `<out_root>/api` becuase the user has
+   * set their root dir to `api`:
+   *
+   * ```
+   * <out_root>/node_modules/
+   * <out_root>/api/app.ts
+   * <out_root>/api/index.ts
+   * ```
+   *
+   * But here, `source_root` is `<out_root>` because the user has set their root
+   * dir to `.`:
+   *
+   * ```
+   * <out_source_root>/node_modules/
+   * <out_source_root>/app.ts
+   * <out_source_root>/index.ts
+   * ```
+   */
+  sourceRoot: string
 }
 
 /**
@@ -477,13 +521,21 @@ function getBuildInfo(
       startModuleInPath,
       startModuleOutPath,
       bundleOutputDir: null,
+      startModule: startModuleOutPath,
+      root: tsOutputDir,
+      sourceRoot: tsOutputDir,
     }
   }
 
   const tsBuildInfo = getBuildInfo(TMP_TS_BUILD_FOLDER_PATH_RELATIVE_TO_PROJECT_ROOT, scanResult, false)
+  const relativeRootDir = Path.relative(scanResult.projectRoot, scanResult.tsConfig.content.options.rootDir!)
+  const sourceRoot = Path.join(tsOutputDir, relativeRootDir)
 
   return {
     ...tsBuildInfo,
     bundleOutputDir: tsOutputDir,
+    root: tsOutputDir,
+    startModule: Path.join(sourceRoot, START_MODULE_NAME + '.js'),
+    sourceRoot,
   }
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -392,3 +392,26 @@ export function deserializeError(se: SerializedError): Error {
 }
 
 export function noop() {}
+
+/**
+ * This makes the optimally pretty import path following Node's algorithm.
+ *
+ * @example
+ *
+ * ```
+ * foo -> foo
+ * ```
+ * ```
+ * foo/bar -> foo/bar
+ * ```
+ * ```
+ * foo/bar/index.js -> foo/bar
+ * ```
+ */
+export function prettyImportPath(id: string): string {
+  const { dir, name } = Path.parse(id)
+
+  if (name === 'index') return dir
+
+  return id
+}


### PR DESCRIPTION
closes #919

This change also does some slight refactoring by keeping more information in layout.

This change also improves the Heroku start module check in two ways.

First by being more flexible about what is tolerated in the start script. For example it is not possible to pass flags to node in the start script.

Second, some colouring to make more clear to the user what is wrong and what a fix looks like.


#### TODO

- [x] ~tests~ (left some todos for now...)