### PR TITLE
half baked bail on occupied port

### DIFF
--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -12,7 +12,8 @@ export function fatal(errOrMsg: string | Error, context?: Record<string, unknown
   } else {
     log.fatal(errOrMsg, context)
   }
-  process.exit(1)
+  process.send!("exit", {err: errOrMsg, context});
+  process.exit(1);
 }
 
 export type SuccessfulRunResult = {

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -14,6 +14,7 @@ import { createRequestHandlerGraphQL } from './handler-graphql'
 import { createRequestHandlerPlayground } from './handler-playground'
 import { log } from './logger'
 import { createServerSettingsManager } from './settings'
+import { fatal } from '../../lib/process'
 
 const resolverLogger = log.child('graphql')
 
@@ -72,6 +73,11 @@ export function create(appState: AppState) {
       },
       assemble(loadedRuntimePlugins: Plugin.RuntimeContributions[], schema: GraphQLSchema) {
         state.httpServer.on('request', express)
+        state.httpServer.on('error', async function (err: NodeJS.ErrnoException)  {
+          if (err.code === 'EADDRINUSE') {
+            fatal(`Port ${settings.data.port} is already in use.`, { ...err })
+          }
+        });
 
         if (settings.data.playground) {
           express.get(


### PR DESCRIPTION
After adding `graphqlgen` run and build configs were spawning nexus all over the place, so I figured bailing on a used port would be easy enough to implement without appreciating the process tree nexus spins up. Could someone familiar with the ExitSystem give this a quick look?

#### TODO

- [ ] integrate handler with ExitSystem
- [ ] docs
- [ ] tests
