### PR TITLE
refactor(layout): return either type

### DIFF
--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 import prompts from 'prompts'
 import { PackageJson } from 'type-fest'
 import { Command } from '../../../lib/cli'
+import { rightOrFatal } from '../../../lib/glocal/utils'
 import * as Layout from '../../../lib/layout'
 import { tsconfigTemplate } from '../../../lib/layout/tsconfig'
 import { rootLogger } from '../../../lib/nexus-logger'
@@ -52,7 +53,7 @@ export async function runLocalHandOff(): Promise<void> {
   log.trace('start local handoff')
 
   const parentData = await loadDataFromParentProcess()
-  const layout = await Layout.create()
+  const layout = rightOrFatal(await Layout.create())
   const pluginM = await PluginWorktime.getUsedPlugins(layout)
   const plugins = PluginRuntime.importAndLoadWorktimePlugins(pluginM, layout)
   log.trace('plugins', { plugins })

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -1,6 +1,7 @@
 import { stripIndent } from 'common-tags'
 import { ts } from 'ts-morph'
 import { arg, Command, isError } from '../../lib/cli'
+import { rightOrFatal } from '../../lib/glocal/utils'
 import * as Layout from '../../lib/layout'
 import { rootLogger } from '../../lib/nexus-logger'
 import { ownPackage } from '../../lib/own-package'
@@ -38,7 +39,7 @@ export class Dev implements Command {
 
     const entrypointPath = args['--entrypoint']
     const reflectionMode = args['--reflection'] === true
-    let layout = await Layout.create({ entrypointPath })
+    let layout = rightOrFatal(await Layout.create({ entrypointPath }))
     const pluginReflectionResult = await Reflection.reflect(layout, { usedPlugins: true, onMainThread: true })
 
     // TODO: Do not fatal if reflection failed.
@@ -90,7 +91,7 @@ export class Dev implements Command {
             change.type === 'unlinkDir'
           ) {
             log.trace('analyzing project layout')
-            layout = await Layout.create({ entrypointPath })
+            layout = rightOrFatal(await Layout.create({ entrypointPath }))
           }
 
           if (args['--reflection']) {

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -28,6 +28,7 @@ export class Report implements Command {
       return
     }
 
+    // todo copy-paste this to user clipboard
     console.log('```json' + EOL + JSON.stringify(report, null, 2) + EOL + '```')
   }
 }

--- a/src/lib/build/build.ts
+++ b/src/lib/build/build.ts
@@ -8,6 +8,7 @@ import {
   prepareStartModule,
   START_MODULE_NAME,
 } from '../../runtime/start/start-module'
+import { rightOrFatal } from '../glocal/utils'
 import { rootLogger } from '../nexus-logger'
 import * as Plugin from '../plugin'
 import { fatal } from '../process'
@@ -38,12 +39,14 @@ export async function buildNexusApp(settings: BuildSettings) {
   const deploymentTarget = normalizeTarget(settings.target)
   const buildOutput = settings.output ?? computeBuildOutputFromTarget(deploymentTarget) ?? undefined
 
-  const layout = await Layout.create({
-    buildOutputDir: buildOutput,
-    asBundle: settings.asBundle,
-    entrypointPath: settings.entrypoint,
-    cwd: settings.cwd,
-  })
+  const layout = rightOrFatal(
+    await Layout.create({
+      buildOutputDir: buildOutput,
+      asBundle: settings.asBundle,
+      entrypointPath: settings.entrypoint,
+      cwd: settings.cwd,
+    })
+  )
 
   /**
    * Delete the TS incremental file to make sure we're building from a clean slate

--- a/src/lib/glocal/utils.ts
+++ b/src/lib/glocal/utils.ts
@@ -1,5 +1,7 @@
+import { Either, isLeft, isRight } from 'fp-ts/lib/Either'
 import * as path from 'path'
 import { findFileRecurisvelyUpwardSync } from '../fs'
+import { fatal } from '../process'
 
 /**
  * Handoff execution from a global to local version of a package.
@@ -19,4 +21,36 @@ export function globalToLocalModule(input: { localPackageDir: string; globalPack
   }
 
   require(path.join(input.localPackageDir, path.relative(globalProjectDir, input.globalPackageFilename)))
+}
+
+/**
+ * Extract the left value from an Either.
+ */
+export function getLeft<A, B>(e: Either<A, B>): A | undefined {
+  if (isLeft(e)) return e.left
+  return undefined
+}
+
+/**
+ * Extract the right value from an Either.
+ */
+export function getRight<A, B>(e: Either<A, B>): B | undefined {
+  if (isRight(e)) return e.right
+  return undefined
+}
+
+/**
+ * Extract the right value from an Either or throw.
+ */
+export function rightOrThrow<A extends Error, B>(x: Either<A, B>): B {
+  if (isLeft(x)) throw x.left
+  return x.right
+}
+
+/**
+ * Extract the right value from an Either or throw.
+ */
+export function rightOrFatal<A extends Error, B>(x: Either<A, B>): B {
+  if (isLeft(x)) fatal(x.left)
+  return x.right
 }

--- a/src/lib/layout/index.spec.ts
+++ b/src/lib/layout/index.spec.ts
@@ -18,6 +18,7 @@ import stripAnsi from 'strip-ansi'
 import { TsConfigJson } from 'type-fest'
 import * as Layout from '.'
 import { FSSpec, writeFSSpec } from '../../lib/testing-utils'
+import { rightOrThrow } from '../glocal/utils'
 import * as TC from '../test-context'
 import { repalceInObject } from '../utils'
 import { NEXUS_TS_LSP_IMPORT_ID } from './tsconfig'
@@ -65,12 +66,14 @@ const ctx = TC.create(
         writeFSSpec(ctx.tmpDir, spec)
       },
       async scan(opts?: { entrypointPath?: string; buildOutput?: string }) {
-        const data = await Layout.create({
-          cwd: ctx.tmpDir,
-          entrypointPath: opts?.entrypointPath,
-          buildOutputDir: opts?.buildOutput,
-          asBundle: false,
-        })
+        const data = rightOrThrow(
+          await Layout.create({
+            cwd: ctx.tmpDir,
+            entrypointPath: opts?.entrypointPath,
+            buildOutputDir: opts?.buildOutput,
+            asBundle: false,
+          })
+        )
         mockedStdoutBuffer = mockedStdoutBuffer.split(ctx.tmpDir).join('__DYNAMIC__')
         return repalceInObject(ctx.tmpDir, '__DYNAMIC__', data.data)
       },

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -3,25 +3,27 @@
  * about the proejct and environment and can format them for a GitHub issue.
  */
 
+import { Either, isLeft } from 'fp-ts/lib/Either'
 import os from 'os'
 import { PackageJson } from 'type-fest'
-import * as PluginWorktime from './plugin/worktime'
-import * as PluginRuntime from './plugin'
 import { Layout } from './layout'
+import * as PluginRuntime from './plugin'
+import * as PluginWorktime from './plugin/worktime'
 
 interface Report {
-  nexus: string
-  plugins: string[]
   node: string
   os: {
     platform: string
     release: string
   }
-  otherDependencies: PackageJson['dependencies']
-  devDependencies: PackageJson['devDependencies']
-  hasAppModule: boolean
-  packageManager: Layout['packageManagerType']
+  nexus?: string
+  plugins?: string[]
+  otherDependencies?: PackageJson['dependencies']
+  devDependencies?: PackageJson['devDependencies']
+  hasAppModule?: boolean
+  packageManager?: Layout['packageManagerType']
   errorsWhileGatheringReport: {
+    gettingLayout: null | Error
     gettingPluginManifests: null | string[]
   }
 }
@@ -29,7 +31,18 @@ interface Report {
 /**
  * Extract diagnostics about the Nexus project.
  */
-export async function getNexusReport(layout: Layout): Promise<Report> {
+export async function getNexusReport(errLayout: Either<Error, Layout>): Promise<Report> {
+  if (isLeft(errLayout)) {
+    return {
+      ...getBaseReport(),
+      errorsWhileGatheringReport: {
+        gettingLayout: errLayout.left,
+        gettingPluginManifests: null,
+      },
+    }
+  }
+
+  const layout = errLayout.right
   const pj = layout.packageJson?.content
   const deps = pj?.dependencies ?? {}
   const otherDeps = Object.fromEntries(
@@ -41,21 +54,31 @@ export async function getNexusReport(layout: Layout): Promise<Report> {
   const gotManifests = PluginRuntime.getPluginManifests(pluginEntrypoints)
 
   return {
-    node: process.version,
+    ...getBaseReport(),
     nexus: deps.nexus ?? 'undefined',
     plugins: gotManifests.data.map((m) => m.name),
-    os: {
-      platform: os.platform(),
-      release: os.release(),
-    },
     otherDependencies: otherDeps,
     devDependencies: pj?.devDependencies ?? {},
     hasAppModule: layout.data.app.exists,
     packageManager: layout.packageManagerType,
     errorsWhileGatheringReport: {
+      gettingLayout: null,
       gettingPluginManifests: gotManifests.errors
         ? gotManifests.errors.map((e) => e.stack ?? e.message)
         : null,
+    },
+  }
+}
+
+/**
+ * Generic report data about user system, not particular to Nexus.
+ */
+export function getBaseReport() {
+  return {
+    node: process.version,
+    os: {
+      platform: os.platform(),
+      release: os.release(),
     },
   }
 }

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -1,6 +1,7 @@
 import { isLeft } from 'fp-ts/lib/Either'
 import getPort from 'get-port'
 import * as Lo from 'lodash'
+import { rightOrFatal } from '../lib/glocal/utils'
 import { GraphQLClient } from '../lib/graphql-client'
 import * as Layout from '../lib/layout'
 import { rootLogger } from '../lib/nexus-logger'
@@ -80,7 +81,7 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
   process.env.NEXUS_STAGE = 'dev'
 
   // todo figure out some caching system here, e.g. imagine jest --watch mode
-  const layout = await Layout.create({ entrypointPath: opts?.entrypointPath })
+  const layout = rightOrFatal(await Layout.create({ entrypointPath: opts?.entrypointPath }))
   const pluginManifests = await PluginWorktime.getUsedPlugins(layout)
   const randomPort = await getPort({ port: getPort.makeRange(4000, 6000) })
   const privateApp = app as PrivateApp


### PR DESCRIPTION
This refactor just changes the return type of layout, and then handles the
cascading updates needed.

This small step puts us in a position to more easily refactor all the
fatals within/under the layout moudle, of which there are many.