### PR TITLE
chore(docs): fix directory in example start script

### DIFF
--- a/docs/references/recipes.md
+++ b/docs/references/recipes.md
@@ -137,7 +137,7 @@ If you don't want to use a docker, here are some links to alternative approaches
 
    ```diff
    +++ package.json
-   + "start": "node .nexus/build"
+   + "start": "node .nexus/build/api"
    ```
 
 3. In many cases this will be enough. Many deployment platforms will call into these scripts by default. You can customize where `build` outputs to if your deployment platform requires it. There are built in guides for `vercel` and `heroku` which will check your project is prepared for deployment to those respective platforms. Take advantage of them if applicable:


### PR DESCRIPTION
Addresses typo mentioned in #640.

#### TODO

- [x] docs
- [x] tests

Ran with clean `npx nexus`. Not sure if this changed recently. FWIW `rootDir` changes nothing without `outDir` being specified. People may be compiling things outside of `api`, obviously, but if nexus specifies the root and `includes` in the generator it'd be a little cleaner to get rid of the extra nested dir. By that I mean relocate `api/*` to `.nexus/build` to keep the structure a little more obvious.
