### PR TITLE
feat(playground): expose UI config defaults via settings

### DIFF
--- a/docs/api/modules/main/exports/settings.md
+++ b/docs/api/modules/main/exports/settings.md
@@ -13,7 +13,7 @@ Use the settings to centrally configure various aspects of the various component
     port?: number
     host?: string
     path?: string
-    playground?: boolean | { path?: string }
+    playground?: boolean | { path?: string, clientSettings?: PlaygroundClientSettings }
   }
   schema?: {
     nullable?: {
@@ -50,10 +50,10 @@ Change your app's current settings. This is an additive API meaning it can be ca
 <div class="OneLineSignature"></div>
 
 ```
-boolean
+boolean | { path?: string, clientSettings?: PlaygroundClientSettings }
 ```
 
-Should the app expose a [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) to clients?
+Should the app expose a [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) to clients? Client configuration options are defined [here](https://github.com/prisma-labs/graphql-playground/blob/40c35fc4c73b939d002c9d2dff51eed5dd0b6aa9/packages/graphql-playground-react/src/types.ts#L19-L36).
 
 _Default_
 

--- a/src/runtime/server/handler-playground.ts
+++ b/src/runtime/server/handler-playground.ts
@@ -1,8 +1,10 @@
 import type { NexusRequestHandler } from './server'
 import { sendResponse } from './utils'
+import { PlaygroundClientSettings } from './settings'
 
 type Settings = {
   graphqlEndpoint: string
+  clientSettings: PlaygroundClientSettings
 }
 
 type Handler = (settings: Settings) => NexusRequestHandler
@@ -67,7 +69,8 @@ export const createRequestHandlerPlayground: Handler = (settings) => (_req, res)
       <script>
         window.addEventListener('load', function (event) {
           GraphQLPlayground.init(document.getElementById('root'), {
-            endpoint: '${settings.graphqlEndpoint}'
+            endpoint: '${settings.graphqlEndpoint}',
+            settings: ${JSON.stringify(settings.clientSettings)}
           })
         })
       </script>

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -46,7 +46,10 @@ export function create(appState: AppState) {
           assembledGuard(appState, 'app.server.handlers.playground', () => {
             // todo should be accessing settings from assembled app state settings
             return wrapHandlerWithErrorHandling(
-              createRequestHandlerPlayground({ graphqlEndpoint: settings.data.path })
+              createRequestHandlerPlayground({
+                graphqlEndpoint: settings.data.path,
+                clientSettings: settings.data.playground ? settings.data.playground.clientSettings : {},
+              })
             )
           }) ?? noop
         )
@@ -77,7 +80,10 @@ export function create(appState: AppState) {
           express.get(
             settings.data.playground.path,
             wrapHandlerWithErrorHandling(
-              createRequestHandlerPlayground({ graphqlEndpoint: settings.data.path })
+              createRequestHandlerPlayground({
+                graphqlEndpoint: settings.data.path,
+                clientSettings: settings.data.playground ? settings.data.playground.clientSettings : {},
+              })
             )
           )
         }

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -4,10 +4,6 @@ import { log as serverLogger } from './logger'
 
 const log = serverLogger.child('settings')
 
-export type PlaygroundSettings = {
-  path?: string
-}
-
 export type SettingsInput = {
   /**
    * todo
@@ -59,8 +55,57 @@ export type SettingsData = Omit<Utils.DeepRequired<SettingsInput>, 'host' | 'pla
 
 export const defaultPlaygroundPath = '/'
 
+/*
+ * Typings and defaults for `graphql-playground-react`
+ * https://github.com/prisma-labs/graphql-playground/blob/master/packages/graphql-playground-react/src/types.ts
+ */
+export type PlaygroundCursorShape = 'line' | 'block' | 'underline'
+export type PlaygroundTheme = 'dark' | 'light'
+
+export type PlaygroundClientSettings = {
+  'editor.cursorShape'?: PlaygroundCursorShape
+  'editor.fontFamily'?: string
+  'editor.fontSize'?: number
+  'editor.reuseHeaders'?: boolean
+  'editor.theme'?: PlaygroundTheme
+  'general.betaUpdates'?: boolean
+  'prettier.printWidth'?: number
+  'prettier.tabWidth'?: number
+  'prettier.useTabs'?: boolean
+  'request.credentials'?: 'omit' | 'include' | 'same-origin'
+  'schema.disableComments'?: boolean
+  'schema.polling.enable'?: boolean
+  'schema.polling.endpointFilter'?: string
+  'schema.polling.interval'?: number
+  'tracing.hideTracingResponse'?: boolean
+  'tracing.tracingSupported'?: boolean
+}
+
+export type PlaygroundSettings = {
+  path?: string
+  clientSettings?: PlaygroundClientSettings
+}
+
 export const defaultPlaygroundSettings: () => Readonly<Required<PlaygroundSettings>> = () => ({
   path: defaultPlaygroundPath,
+  clientSettings: {
+    'editor.cursorShape': 'line',
+    'editor.fontFamily': `'Source Code Pro', 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace'`,
+    'editor.fontSize': 14,
+    'editor.reuseHeaders': true,
+    'editor.theme': 'dark',
+    'general.betaUpdates': false,
+    'prettier.printWidth': 80,
+    'prettier.tabWidth': 2,
+    'prettier.useTabs': false,
+    'request.credentials': 'same-origin',
+    'schema.disableComments': true,
+    'schema.polling.enable': true,
+    'schema.polling.endpointFilter': '*localhost*',
+    'schema.polling.interval': 2000,
+    'tracing.hideTracingResponse': true,
+    'tracing.tracingSupported': true,
+  },
 })
 
 /**
@@ -116,8 +161,11 @@ export function playgroundSettings(settings: SettingsInput['playground']): Setti
     return false
   }
 
+  const clientDefaults = defaultPlaygroundSettings().clientSettings
   return {
     path: playgroundPath(settings),
+    clientSettings:
+      typeof settings === 'boolean' ? clientDefaults : { ...clientDefaults, ...settings.clientSettings },
   }
 }
 


### PR DESCRIPTION
Personally, I needed access to the default UI configuration to include credentials... but why stop there. This allows setting of `graphql-playground-react`'s client-side options. Since nexus doesn't include the playground as dependency and its typings are bundled, the settings typedefs are copied from their source. FWIW they [haven't changed in years](https://github.com/prisma-labs/graphql-playground/blame/40c35fc4c73b939d002c9d2dff51eed5dd0b6aa9/packages/graphql-playground-react/src/types.ts#L19-L36).

- [x] docs
- [ ] tests
