### PR TITLE
chore(docs): use bullets for clarity in tutorial chapter 5

### DIFF
--- a/docs/tutorial/chapter-5-persisting-data-via-prisma.md
+++ b/docs/tutorial/chapter-5-persisting-data-via-prisma.md
@@ -16,9 +16,9 @@ Its important to understand that Nexus does not _require_ these technology choic
 
 So, what _is_ Prisma? It is an open source database toolkit that consists of the following parts:
 
-**Prisma Client**: Auto-generated and type-safe query builder for Node.js & TypeScript
-**Prisma Migrate** (experimental): Declarative data modeling & migration system
-**Prisma Studio** (experimental): GUI to view and edit data in your database
+- **Prisma Client**: Auto-generated and type-safe query builder for Node.js & TypeScript
+- **Prisma Migrate** (experimental): Declarative data modeling & migration system
+- **Prisma Studio** (experimental): GUI to view and edit data in your database
 
 At the heart of Prisma is the _Prisma Schema,_ a file usually called `schema.prisma`, that you will see later in this tutorial. It is a declarative file wherein using a domain specific language you encode your database schema, connection to the database, and more.
 


### PR DESCRIPTION
Update `chapter-5-persisting-data-via-prisma.md`:

Added bullets to prisma parts list so that each part is displayed on its own like, and not run together.

I was reading through and the paragraph looked weird, I assume from the line breaks in the md source that my change matches the author's intention more closely as well.