### PR TITLE
feat(server): expose node http server instance

### DIFF
--- a/docs/api/modules/main/exports/server.md
+++ b/docs/api/modules/main/exports/server.md
@@ -19,7 +19,7 @@ import { server } from 'nexus'
 server.express.use(cors())
 ```
 
-### `raw.engine`
+### `raw.http`
 
 The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
 

--- a/docs/api/modules/main/exports/server.md
+++ b/docs/api/modules/main/exports/server.md
@@ -21,6 +21,6 @@ server.express.use(cors())
 
 ### `raw.engine`
 
-Gives you access to the underlying [Node HTTP `Server`](https://nodejs.org/api/http.html#http_class_http_server) instance.
+The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
 
-This is an escape hatch. Only use for advanced use-cases.
+Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case.

--- a/docs/api/modules/main/exports/server.md
+++ b/docs/api/modules/main/exports/server.md
@@ -23,4 +23,4 @@ server.express.use(cors())
 
 The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
 
-Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case.
+Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case. Maybe Nexus can and should provide better first-class support for what you are trying to do!

--- a/docs/api/modules/main/exports/server.md
+++ b/docs/api/modules/main/exports/server.md
@@ -18,3 +18,9 @@ import { server } from 'nexus'
 
 server.express.use(cors())
 ```
+
+### `raw.engine`
+
+Gives you access to the underlying [Node HTTP `Server`](https://nodejs.org/api/http.html#http_class_http_server) instance.
+
+This is an escape hatch. Only use for advanced use-cases.

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,5 @@
+import * as HTTP from 'http'
+import * as Net from 'net'
 import * as Path from 'path'
 import Git from 'simple-git/promise'
 import { JsonObject, PackageJson, Primitive } from 'type-fest'
@@ -436,3 +438,23 @@ export function prettyImportPath(id: string): string {
 }
 
 type SomeRecord = Record<string, unknown>
+
+export function httpListen(server: HTTP.Server, options: Net.ListenOptions): Promise<void> {
+  return new Promise((res, rej) => {
+    server.listen(options, () => {
+      res()
+    })
+  })
+}
+
+export function httpClose(server: HTTP.Server): Promise<void> {
+  return new Promise((res, rej) => {
+    server.close((err) => {
+      if (err) {
+        rej(err)
+      } else {
+        res()
+      }
+    })
+  })
+}

--- a/src/runtime/app.spec.ts
+++ b/src/runtime/app.spec.ts
@@ -1,4 +1,5 @@
 import { log } from '@nexus/logger'
+import * as HTTP from 'http'
 import * as Lo from 'lodash'
 import { removeReflectionStage, setReflectionStage } from '../lib/reflection'
 import * as App from './app'
@@ -83,18 +84,24 @@ describe('checks', () => {
   })
 })
 
-describe('server handlers', () => {
-  it('under reflection are noops', () => {
-    setReflectionStage('plugin')
-    const g = app.server.handlers.graphql as any
-    const p = app.server.handlers.playground as any
-    expect(g()).toBeUndefined()
-    expect(p()).toBeUndefined()
-    removeReflectionStage()
+describe('server', () => {
+  it('has raw.engine to get access to underling node http server', () => {
+    expect(app.server.raw.engine).toBeInstanceOf(HTTP.Server)
   })
 
-  // todo, process exit poop
-  it.todo('if accessed before assembly, and not under reflection, error')
+  describe('handlers', () => {
+    it('under reflection are noops', () => {
+      setReflectionStage('plugin')
+      const g = app.server.handlers.graphql as any
+      const p = app.server.handlers.playground as any
+      expect(g()).toBeUndefined()
+      expect(p()).toBeUndefined()
+      removeReflectionStage()
+    })
+
+    // todo, process exit poop
+    it.todo('if accessed before assembly, and not under reflection, error')
+  })
 })
 
 /**

--- a/src/runtime/app.spec.ts
+++ b/src/runtime/app.spec.ts
@@ -85,8 +85,8 @@ describe('checks', () => {
 })
 
 describe('server', () => {
-  it('has raw.engine to get access to underling node http server', () => {
-    expect(app.server.raw.engine).toBeInstanceOf(HTTP.Server)
+  it('has raw.http to get access to underling node http server', () => {
+    expect(app.server.raw.http).toBeInstanceOf(HTTP.Server)
   })
 
   describe('handlers', () => {

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -29,6 +29,11 @@ export interface Server {
    * For advanced use only.
    */
   raw: {
+    /**
+     * The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
+     *
+     * Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case.
+     */
     engine: HTTP.Server
   }
   express: Express

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -34,7 +34,7 @@ export interface Server {
      *
      * Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case. Maybe Nexus can and should provide better first-class support for what you are trying to do!
      */
-    engine: HTTP.Server
+    http: HTTP.Server
   }
   express: Express
   handlers: {
@@ -56,7 +56,7 @@ export function create(appState: AppState) {
 
   const api: Server = {
     raw: {
-      engine: state.httpServer,
+      http: state.httpServer,
     },
     express,
     handlers: {

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -24,7 +24,7 @@ export type NexusRequestHandler = (req: HTTP.IncomingMessage, res: HTTP.ServerRe
  */
 export interface Server {
   /**
-   * Escape hatch to access Nexus server internals.
+   * Escape hatches to various Nexus server internals.
    *
    * These things are available mostly as escape hatches, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case. Maybe Nexus can and should provide better first-class support for what you are trying to do!
    */

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -26,13 +26,13 @@ export interface Server {
   /**
    * Escape hatch to access Nexus server internals.
    *
-   * For advanced use only.
+   * These things are available mostly as escape hatches, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case. Maybe Nexus can and should provide better first-class support for what you are trying to do!
    */
   raw: {
     /**
      * The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
      *
-     * Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case.
+     * Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case. Maybe Nexus can and should provide better first-class support for what you are trying to do!
      */
     engine: HTTP.Server
   }

--- a/website/content/04-api/01-nexus/03-server.mdx
+++ b/website/content/04-api/01-nexus/03-server.mdx
@@ -22,3 +22,9 @@ import { server } from 'nexus'
 
 server.express.use(cors())
 ```
+
+## `raw.engine`
+
+Gives you access to the underlying [Node HTTP `Server`](https://nodejs.org/api/http.html#http_class_http_server) instance.
+
+This is an escape hatch. Only use for advanced use-cases.

--- a/website/content/04-api/01-nexus/03-server.mdx
+++ b/website/content/04-api/01-nexus/03-server.mdx
@@ -27,4 +27,4 @@ server.express.use(cors())
 
 The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
 
-Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case.
+Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case. Maybe Nexus can and should provide better first-class support for what you are trying to do!

--- a/website/content/04-api/01-nexus/03-server.mdx
+++ b/website/content/04-api/01-nexus/03-server.mdx
@@ -25,6 +25,6 @@ server.express.use(cors())
 
 ## `raw.engine`
 
-Gives you access to the underlying [Node HTTP `Server`](https://nodejs.org/api/http.html#http_class_http_server) instance.
+The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
 
-This is an escape hatch. Only use for advanced use-cases.
+Access to this is made available mostly as an escape hatch, and maybe a few valid advanced use-cases. If you haven't already/are not sure, consider [opening an issue](https://nxs.li/issues/create/feature) for your use-case.

--- a/website/content/04-api/01-nexus/03-server.mdx
+++ b/website/content/04-api/01-nexus/03-server.mdx
@@ -23,7 +23,7 @@ import { server } from 'nexus'
 server.express.use(cors())
 ```
 
-## `raw.engine`
+## `raw.http`
 
 The underlying [Node HTTP Server](https://nodejs.org/api/http.html#http_class_http_server) instance.
 


### PR DESCRIPTION
This exposes the underlying Node HTTP Server instance. It is placed under `raw` to make clear that it is not for normal day to day use.

This feature was motivated to support things like #278 

While we wish, as a framework, this didn't have to exist, we don't want to be a bottleneck for the community to experiment and collaborate. Thus escape hatches like this.

closes #840


#### TODO

- [x] docs
- [x] tests