### PR TITLE
feat(tsconfig): support type-roots

### DIFF
--- a/docs/guides/project-layout.md
+++ b/docs/guides/project-layout.md
@@ -39,9 +39,32 @@ Autocomplete with Nexus TS LSP:
 
 Nexus has some conventions about `tsconfig.json` settings designed to support your zero-config experience.
 
-###### Local Typing Declaration File
+###### Local Package Typings
 
-Sometimes you need to augment or provide outright types for some third party library. Do this by creating a `types.d.ts` in your project root. Nexus automatically configures `tsconfig.json` to pick this file up.
+Sometimes you need to augment or provide outright types for some third party library. You can do this one of two ways.
+
+If you only have to write some minor typings for one or few packages then you can create a `<project-root>/types.d.ts` file.
+
+If you have to write a lot of typings for multiple packages then you can create typing files with this pattern:
+
+```
+<project-roo>/types/       <-- A "types" folder instead of "types.d.ts" file
+  <package-name>/          <-- Name not technically significant, just for human readability, do what you want
+    index.d.ts             <-- Typings
+```
+
+Nexus automatically configures `tsconfig.json` to correctly pick up both approaces.
+
+###### noEmit
+
+Nexus enforces that `compilerOptions.noEmit` is `true`. It handles this setting internally. If for some reason you want to run `tsc` you won't need to remember to pass the `--noEmit` flag.
+
+###### typeRoots
+
+Nexus enforces that your `compilerOptions.typeRoots` includes:
+
+- `"node_modules/@types"` –– TypeScript's default value for `typeRoots`. Used by [Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped) packages. Importantly where Nexus outputs its typegen to, so you _must_ have this value.
+- `"types"` –– A convention provided by Nexus about where to store your local package typings.
 
 ## Conventions
 

--- a/src/lib/layout/index.spec.ts
+++ b/src/lib/layout/index.spec.ts
@@ -50,6 +50,7 @@ function tsconfig(input?: TsConfigJson): TsConfigJson {
       noEmit: true,
       rootDir: '.',
       plugins: [{ name: NEXUS_TS_LSP_IMPORT_ID }],
+      typeRoots: ['node_modules/@types', 'types'],
     },
     include: ['types.d.ts', '.'],
   }
@@ -205,6 +206,10 @@ describe('tsconfig', () => {
           "rootDir": ".",
           "strict": true,
           "target": "es2016",
+          "typeRoots": Array [
+            "node_modules/@types",
+            "types",
+          ],
         },
         "include": Array [
           "types.d.ts",
@@ -215,7 +220,7 @@ describe('tsconfig', () => {
   })
 
   describe('composite projects', () => {
-    it('inheritable settigs are recognized but "include", "rootDir", "plugins" must be local', async () => {
+    it('inheritable settigs are recognized but "include", "rootDir", "plugins", "typeRoots" must be local', async () => {
       nestTmpDir()
       ctx.fs.write('src/app.ts', '')
       ctx.fs.write('../tsconfig.packages.json', tsconfigSource())
@@ -228,6 +233,7 @@ describe('tsconfig', () => {
 
             \\"plugins\\": [{ \\"name\\": \\"nexus/typescript-language-service\\" }]
 
+        ▲ nexus:tsconfig Please set [93m\`compilerOptions.typeRoots\`[39m to [93m[\\"node_modules/@types\\",\\"types\\"][39m. \\"node_modules/@types\\" is the TypeScript default for types packages and where Nexus outputs typegen to. \\"types\\" is the Nexus convention for _local_ types packages.
         ▲ nexus:tsconfig Please add [93m\\"types.d.ts\\"[39m to your [93m\\"include\\"[39m array. If you do not then results from Nexus and your IDE will not agree if the declaration file is used in your project.
         ▲ nexus:tsconfig Please set [93m\`compilerOptions.rootDir\`[39m to [93m\\".\\"[39m
         ▲ nexus:tsconfig Please set [93m\`include\`[39m to have \\".\\"
@@ -320,25 +326,81 @@ describe('tsconfig', () => {
         "
       `)
     })
-    it('does not support use of compilerOptions.rootTypes', async () => {
-      ctx.setup({
-        'tsconfig.json': tsconfigSource({ compilerOptions: { typeRoots: [] } }),
+
+    describe('typeRoots', () => {
+      it('logs error if typeRoots present but missing "node_modules/@types", and adds it in-memory', async () => {
+        const tscfg = tsconfig()
+        tscfg.compilerOptions!.typeRoots = ['types']
+        ctx.setup({
+          'tsconfig.json': JSON.stringify(tscfg),
+        })
+        const res = await ctx.createLayout().then(rightOrThrow)
+        expect(logs).toMatchInlineSnapshot(`
+                  "■ nexus:tsconfig Please add [93m\\"node_modules/@types\\"[39m to your [93m\`compilerOptions.typeRoots\`[39m array. 
+                  "
+              `)
+        expect(res.tsConfig.content.options.typeRoots).toMatchInlineSnapshot(`
+                  Array [
+                    "__DYNAMIC__/types",
+                    "__DYNAMIC__/node_modules/@types",
+                  ]
+              `)
       })
-      await ctx.createLayoutThrow()
-      expect(logs).toMatchInlineSnapshot(`
-        "■ nexus:tsconfig You have set [93m\`compilerOptions.typeRoots\`[39m but Nexus does not support it. If you do not remove your customization you may/will (e.g. VSCode) see inconsistent results between your IDE and what Nexus tells you at build time. If you would like to see Nexus support this setting please chime in at https://github.com/graphql-nexus/nexus/issues/1036.
-        "
-      `)
-    })
-    it('outputs warning only once if both types and typeRoots is set', async () => {
-      ctx.setup({
-        'tsconfig.json': tsconfigSource({ compilerOptions: { typeRoots: [], types: [] } }),
+      it('logs warning if "typeRoots" present but msising "types", and adds it in-memory', async () => {
+        const tscfg = tsconfig()
+        tscfg.compilerOptions!.typeRoots = ['node_modules/@types']
+        ctx.setup({
+          'tsconfig.json': JSON.stringify(tscfg),
+        })
+        const res = await ctx.createLayout().then(rightOrThrow)
+        expect(logs).toMatchInlineSnapshot(`
+                  "▲ nexus:tsconfig Please add [93m\\"types\\"[39m to your [93m\`compilerOptions.typeRoots\`[39m array. 
+                  "
+              `)
+        expect(res.tsConfig.content.options.typeRoots).toMatchInlineSnapshot(`
+                  Array [
+                    "__DYNAMIC__/node_modules/@types",
+                    "__DYNAMIC__/types",
+                  ]
+              `)
       })
-      await ctx.createLayoutThrow()
-      expect(logs).toMatchInlineSnapshot(`
-        "■ nexus:tsconfig You have set [93m\`compilerOptions.typeRoots\`[39m and [93m\`compilerOptions.types\`[39m but Nexus does not support them. If you do not remove your customization you may/will (e.g. VSCode) see inconsistent results between your IDE and what Nexus tells you at build time. If you would like to see Nexus support these settings please chime in at https://github.com/graphql-nexus/nexus/issues/1036.
-        "
-      `)
+      it('logs warning if "typeRoots" missing, and add its in-memory', async () => {
+        const tscfg = tsconfig()
+        delete tscfg.compilerOptions!.typeRoots
+        ctx.setup({
+          'tsconfig.json': JSON.stringify(tscfg),
+        })
+        const res = await ctx.createLayout().then(rightOrThrow)
+        expect(logs).toMatchInlineSnapshot(`
+          "▲ nexus:tsconfig Please set [93m\`compilerOptions.typeRoots\`[39m to [93m[\\"node_modules/@types\\",\\"types\\"][39m. \\"node_modules/@types\\" is the TypeScript default for types packages and where Nexus outputs typegen to. \\"types\\" is the Nexus convention for _local_ types packages.
+          "
+        `)
+        expect(res.tsConfig.content.options.typeRoots).toMatchInlineSnapshot(`
+                  Array [
+                    "__DYNAMIC__/node_modules/@types",
+                    "__DYNAMIC__/types",
+                  ]
+              `)
+      })
+      it('preserves any "typeRoot" settings present', async () => {
+        const tscfg = tsconfig()
+        tscfg.compilerOptions!.typeRoots = ['node_modules/@types', 'custom']
+        ctx.setup({
+          'tsconfig.json': JSON.stringify(tscfg),
+        })
+        const res = await ctx.createLayout().then(rightOrThrow)
+        expect(logs).toMatchInlineSnapshot(`
+                  "▲ nexus:tsconfig Please add [93m\\"types\\"[39m to your [93m\`compilerOptions.typeRoots\`[39m array. 
+                  "
+              `)
+        expect(res.tsConfig.content.options.typeRoots).toMatchInlineSnapshot(`
+                  Array [
+                    "__DYNAMIC__/node_modules/@types",
+                    "__DYNAMIC__/custom",
+                    "__DYNAMIC__/types",
+                  ]
+              `)
+      })
     })
   })
 

--- a/src/lib/layout/index.spec.ts
+++ b/src/lib/layout/index.spec.ts
@@ -242,30 +242,34 @@ describe('tsconfig', () => {
     })
   })
 
-  describe('linting', () => {
-    it('enforces noEmit is true (explicit false)', async () => {
+  describe('no emit', () => {
+    it('warns if "noEmit" is not true (explicit false), and sets "noEmit" to false in memory', async () => {
       ctx.setup({
         'tsconfig.json': tsconfigSource({ compilerOptions: { noEmit: false } }),
       })
-      await ctx.createLayoutThrow()
+      const res = await ctx.createLayoutThrow()
       expect(logs).toMatchInlineSnapshot(`
         "▲ nexus:tsconfig Please set [93m\`compilerOptions.noEmit\`[39m to true. This will ensure you do not accidentally emit using [93m\`$ tsc\`[39m. Use [93m\`$ nexus build\`[39m to build your app and emit JavaScript.
         "
       `)
+      expect(res.tsConfig.content.options.noEmit).toEqual(false)
     })
-    it('enforces noEmit is true (undefined)', async () => {
+    it('warns if "noEmit" is not true (undefined), and sets "noEmit" to false in memory', async () => {
       const tscfg = tsconfig()
       delete tscfg.compilerOptions?.noEmit
 
       ctx.setup({
         'tsconfig.json': JSON.stringify(tscfg),
       })
-      await ctx.createLayoutThrow()
+      const res = await ctx.createLayoutThrow()
       expect(logs).toMatchInlineSnapshot(`
         "▲ nexus:tsconfig Please set [93m\`compilerOptions.noEmit\`[39m to true. This will ensure you do not accidentally emit using [93m\`$ tsc\`[39m. Use [93m\`$ nexus build\`[39m to build your app and emit JavaScript.
         "
       `)
+      expect(res.tsConfig.content.options.noEmit).toEqual(false)
     })
+  })
+  describe('linting', () => {
     it('warns if reserved settings are in use', async () => {
       ctx.setup({
         'tsconfig.json': tsconfigSource({

--- a/src/lib/layout/tsconfig.ts
+++ b/src/lib/layout/tsconfig.ts
@@ -253,8 +253,6 @@ export async function readOrScaffoldTsconfig(input: {
     )
   }
 
-  tsconfigParsed.options.noEmit = false
-
   /**
    * Setup out root (aka. outDir)
    */
@@ -281,6 +279,12 @@ export async function readOrScaffoldTsconfig(input: {
       tsconfigPath
     )
   }
+
+  /**
+   * Forced internal settings
+   */
+
+  tsconfigParsed.options.noEmit = false
 
   /**
    * Validate the tsconfig

--- a/src/lib/layout/tsconfig.ts
+++ b/src/lib/layout/tsconfig.ts
@@ -145,32 +145,73 @@ export async function readOrScaffoldTsconfig(input: {
     log.warn(`You have set ${setting} but it will be ignored by Nexus. Nexus manages this value internally.`)
   }
 
-  const { typeRoots, types } = tsconfigParsed.options
-  if (typeRoots || types) {
+  const { types } = tsconfigParsed.options
+  if (types) {
     delete tsconfigParsed.options.typeRoots
     delete tsconfigParsed.options.types
-    const settingsSet =
-      typeRoots && types
-        ? `${renderSetting('compilerOptions.typeRoots')} and ${renderSetting('compilerOptions.types')}`
-        : typeRoots
-        ? renderSetting('compilerOptions.typeRoots')
-        : renderSetting('compilerOptions.types')
-    const itThem = typeRoots && types ? 'them' : 'it'
-    const thisThese = typeRoots && types ? 'these' : 'this'
-    const s = typeRoots && types ? 's' : ''
+    const setting = renderSetting('compilerOptions.types')
     log.error(
-      `You have set ${settingsSet} but Nexus does not support ${itThem}. If you do not remove your customization you may/will (e.g. VSCode) see inconsistent results between your IDE and what Nexus tells you at build time. If you would like to see Nexus support ${thisThese} setting${s} please chime in at https://github.com/graphql-nexus/nexus/issues/1036.`
+      `You have set ${setting} but Nexus does not support it. If you do not remove your customization you may/will (e.g. VSCode) see inconsistent results between your IDE and what Nexus tells you at build time. If you would like to see Nexus support this setting please chime in at https://github.com/graphql-nexus/nexus/issues/1036.`
     )
   }
 
   /**
-   * Setup types declaration file support
+   * Setup typeRoots
+   */
+  const { typeRoots } = tsconfigSourceOriginal.compilerOptions!
+  const nameAtTypes = 'node_modules/@types'
+  const nameTypes = 'types'
+  const explainAtTypes = `"${nameAtTypes}" is the TypeScript default for types packages and where Nexus outputs typegen to.`
+  const explainTypes = `"${nameTypes}" is the Nexus convention for _local_ types packages.`
+  if (!typeRoots) {
+    const setting = renderSetting('compilerOptions.typeRoots')
+    const val = renderVal([nameAtTypes, nameTypes])
+    const explainsRendered = [explainAtTypes, explainTypes].join(' ')
+    tsconfigSource.compilerOptions.typeRoots = [nameAtTypes, nameTypes]
+    log.warn(`Please set ${setting} to ${val}. ${explainsRendered}`)
+  } else {
+    const vals: string[] = []
+    let missingAtTypes = false
+    let explainAtTypes = ''
+    let explainTypes = ''
+    let explains: string[] = []
+    if (!typeRoots.includes(nameAtTypes)) {
+      missingAtTypes = true
+      explains.push(explainAtTypes)
+      tsconfigSource.compilerOptions.typeRoots!.push(nameAtTypes)
+      vals.push(nameAtTypes)
+    }
+    if (!typeRoots.includes(nameTypes)) {
+      explains.push(explainTypes)
+      tsconfigSource.compilerOptions.typeRoots!.push(nameTypes)
+      vals.push(nameTypes)
+    }
+    if (vals.length) {
+      const setting = renderSetting('compilerOptions.typeRoots')
+      const valsRendered = vals.map(renderVal).join(', ')
+      const explainsRendered = explains.join(' ')
+      // If typeRoots are specified but node_modules/@types is not in them
+      // that's really bad! So elevate log to error level.
+      if (missingAtTypes) {
+        log.error(`Please add ${valsRendered} to your ${setting} array. ${explainsRendered}`)
+      } else {
+        log.warn(`Please add ${valsRendered} to your ${setting} array. ${explainsRendered}`)
+      }
+    }
+  }
+
+  /**
+   * Setup types declaration file support.
+   * Work with local tsconfig source contents as the Nexus convention is
+   * supporting a types.d.ts file at project root and "include" is relative to
+   * the tsconfig it shows up in. Thus We want to lint for local config
+   * presence, not inherited.
    */
 
   if (!tsconfigSourceOriginal.include?.includes('types.d.ts')) {
     tsconfigSource.include.push('types.d.ts')
-    const val = chalk.yellowBright(`"types.d.ts"`)
-    const setting = chalk.yellowBright(`"include"`)
+    const val = renderVal('types.d.ts')
+    const setting = renderVal('include')
     log.warn(
       `Please add ${val} to your ${setting} array. If you do not then results from Nexus and your IDE will not agree if the declaration file is used in your project.`
     )
@@ -187,7 +228,7 @@ export async function readOrScaffoldTsconfig(input: {
   if (!tsconfigSource.compilerOptions.rootDir) {
     tsconfigSource.compilerOptions.rootDir = '.'
     const setting = renderSetting('compilerOptions.rootDir')
-    const val = renderValString(tsconfigSource.compilerOptions.rootDir)
+    const val = renderVal(tsconfigSource.compilerOptions.rootDir)
     log.warn(`Please set ${setting} to ${val}`)
   }
 
@@ -236,7 +277,7 @@ export async function readOrScaffoldTsconfig(input: {
       tsconfigSource,
       ts.sys,
       projectRoot,
-      tsconfigParsed.options,
+      undefined,
       tsconfigPath
     )
   }
@@ -269,6 +310,7 @@ export function tsconfigTemplate(input: { sourceRootRelative: string; outRootRel
       rootDir: sourceRelative,
       noEmit: true,
       plugins: [{ name: 'nexus/typescript-language-service' }],
+      typeRoots: ['node_modules/@types', 'types'],
     },
     include: ['types.d.ts', sourceRelative],
   }
@@ -283,8 +325,8 @@ function renderSetting(setting: string) {
 }
 
 /**
- * Prettify a JSON string value for terminal output.
+ * Prettify a JSON value for terminal output.
  */
-function renderValString(val: string): string {
-  return chalk.yellowBright(`"${val}"`)
+function renderVal(val: unknown): string {
+  return chalk.yellowBright(JSON.stringify(val))
 }

--- a/src/lib/layout/tsconfig.ts
+++ b/src/lib/layout/tsconfig.ts
@@ -158,6 +158,7 @@ export async function readOrScaffoldTsconfig(input: {
   /**
    * Setup typeRoots
    */
+
   const { typeRoots } = tsconfigSourceOriginal.compilerOptions!
   const nameAtTypes = 'node_modules/@types'
   const nameTypes = 'types'

--- a/website/content/02-guides/06-project-layout.mdx
+++ b/website/content/02-guides/06-project-layout.mdx
@@ -43,9 +43,30 @@ Autocomplete with Nexus TS LSP:
 
 Nexus has some conventions about `tsconfig.json` settings designed to support your zero-config experience.
 
-#### Local Typing Declaration File
+#### Local Package Typings
 
-Sometimes you need to augment or provide outright types for some third party library. Do this by creating a `types.d.ts` in your project root. Nexus automatically configures `tsconfig.json` to pick this file up.
+Sometimes you need to augment or provide outright types for some third party library. You can do this one of two ways.
+
+If you only have to write some minor typings for one or few packages then you can create a `<project-root>/types.d.ts` file.
+
+If you have to write a lot of typings for multiple packages then you can create typing files with this pattern:
+
+```
+<project-roo>/types/       <-- A "types" folder instead of "types.d.ts" file
+  <package-name>/          <-- Name not technically significant, just for human readability, do what you want
+    index.d.ts             <-- Typings
+```
+
+#### noEmit
+
+Nexus enforces that `compilerOptions.noEmit` is `true`. It handles this setting internally. If for some reason you want to run `tsc` you won't need to remember to pass the `--noEmit` flag.
+
+#### typeRoots
+
+Nexus enforces that your `compilerOptions.typeRoots` includes:
+
+- `"node_modules/@types"` –– TypeScript's default value for `typeRoots`. Used by [Definitely Typed](https://github.com/DefinitelyTyped/DefinitelyTyped) packages. Importantly where Nexus outputs its typegen to, so you _must_ have this value.
+- `"types"` –– A convention provided by Nexus about where to store your local package typings.
 
 ## Conventions
 


### PR DESCRIPTION
closes #1036

This adds support for `typeRoots`. It introduces the following logic:

- tsconfig MUST have `compilerOptions.typeRoots` set
- tsconfig `compilerOptions.typeRoots` MUST include `"types"`
- tsconfig `compilerOptions.typeRoots` MUST include `"node_modules/@types"`
- tsconfig `compilerOptions.typeRoots` MAY include other values

The product design here is really a cascade of effects:

- want to avoid users having to configure typegen paths
- use ts default of @types
- users can break this
- prevent users from breaking it by removing supprt for typeRoots
- users need typeRoots for custom local package typings
- ok fine, support typeRoots but force the @types value
- and finally, while we're at it, introduce a convention becuase Nexus
  can help users (zero-config) a bit by doing so.

The zero config part will feel real once we hvae automatically updated
tsconfig in place. Soon...


#### TODO

- [x] docs
  - [x] website projet layout guide
- [x] tests