### PR TITLE
fix(graphql-client): make `ctx.client.headers` work

### DIFF
--- a/src/lib/graphql-client/index.ts
+++ b/src/lib/graphql-client/index.ts
@@ -16,7 +16,10 @@ export class GraphQLClient {
   }
 
   send(queryString: string, variables?: Variables) {
-    const headers = this.fetchHeaders
+    const headers = {}
+    for (const [key, value] of this.fetchHeaders.entries()) {
+      headers[key] = value
+    }
     const url = this.url
     const client = new GQLR.GraphQLClient(url, { headers })
     return client.request(queryString, variables)


### PR DESCRIPTION
Currently `ctx.client.headers` does not work in `nexus/testing` due to the structural mismatch between `Headers` from `cross-fetch` and `Headers` from `graphql-request`. 

This PR converts `headers` from `cross-fetch` format to a simple plain object, so that `GraphQLClient` from `graphql-request` can consume it.

 