### PR TITLE
fix: clear console when using prisma

### DIFF
--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -229,7 +229,11 @@ export function clearConsole() {
   /**
    * For convenience, we disable clearing the console when debugging
    */
-  if (process.env.DEBUG !== undefined) {
+  if (
+    process.env.LOG_LEVEL !== undefined ||
+    process.env.LOG_FILTER !== undefined ||
+    process.env.NEXUS_NO_CLEAR !== undefined
+  ) {
     return
   }
 


### PR DESCRIPTION
The "heuristic" to prevent from clearing is now based on the nexus logger. It will prevent from clearing the console on restarts when either:

- LOG_LEVEL
- LOG_FILTERING
- NEXUS_NO_CLEAR

is present in the env. `NEXUS_NO_CLEAR` is added mostly for internal debugging purpose in case we ever need that ourselves.