### PR TITLE
test: add watcher to windows suite

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,43 +18,40 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn -s build
-      - run: yarn -s test runtime/app runtime/schema/settings lib/build runtime/schema/index lib/nexus-schema-backing-types lib/graphql-client runtime/server runtime/schema/settings-mapper lib/plugin lib/add-to-context-extractor lib/glocal lib/layout
-      # todo
-      # lib/watcher
-
-  unit-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn --frozen-lockfile
-      - run: yarn -s build
-      - run: yarn -s test:unit
-
-  system-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-        test-case: [kitchen-sink, create-prisma-app]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install deps
-        run: yarn --frozen-lockfile
-      - run: yarn -s build
-      - name: Setup global git user
-        run: |
-          # For nexus create app flow which will make an init commit
-          git config --global user.name prisma-labs
-          git config --global user.email labs@prisma.io
-      - run: yarn -s test system/${{matrix.test-case}}
+      # - run: yarn -s test runtime/app runtime/schema/settings lib/build runtime/schema/index lib/nexus-schema-backing-types lib/graphql-client runtime/server runtime/schema/settings-mapper lib/plugin lib/add-to-context-extractor lib/glocal lib/layout lib/watcher
+      - run: yarn -s test lib/watcher
+  # unit-tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [10.x, 12.x]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #     - run: yarn --frozen-lockfile
+  #     - run: yarn -s build
+  #     - run: yarn -s test:unit
+  # system-tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [10.x, 12.x]
+  #       test-case: [kitchen-sink, create-prisma-app]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #     - name: Install deps
+  #       run: yarn --frozen-lockfile
+  #     - run: yarn -s build
+  #     - name: Setup global git user
+  #       run: |
+  #         # For nexus create app flow which will make an init commit
+  #         git config --global user.name prisma-labs
+  #         git config --global user.email labs@prisma.io
+  #     - run: yarn -s test system/${{matrix.test-case}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,40 +18,41 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn -s build
-      # - run: yarn -s test runtime/app runtime/schema/settings lib/build runtime/schema/index lib/nexus-schema-backing-types lib/graphql-client runtime/server runtime/schema/settings-mapper lib/plugin lib/add-to-context-extractor lib/glocal lib/layout lib/watcher
-      - run: yarn -s test lib/watcher
-  # unit-tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [10.x, 12.x]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - run: yarn --frozen-lockfile
-  #     - run: yarn -s build
-  #     - run: yarn -s test:unit
-  # system-tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [10.x, 12.x]
-  #       test-case: [kitchen-sink, create-prisma-app]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - name: Install deps
-  #       run: yarn --frozen-lockfile
-  #     - run: yarn -s build
-  #     - name: Setup global git user
-  #       run: |
-  #         # For nexus create app flow which will make an init commit
-  #         git config --global user.name prisma-labs
-  #         git config --global user.email labs@prisma.io
-  #     - run: yarn -s test system/${{matrix.test-case}}
+      - run: yarn -s test runtime/app runtime/schema/settings lib/build runtime/schema/index lib/nexus-schema-backing-types lib/graphql-client runtime/server runtime/schema/settings-mapper lib/plugin lib/add-to-context-extractor lib/glocal lib/layout lib/watcher
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn --frozen-lockfile
+      - run: yarn -s build
+      - run: yarn -s test:unit
+
+  system-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+        test-case: [kitchen-sink, create-prisma-app]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install deps
+        run: yarn --frozen-lockfile
+      - run: yarn -s build
+      - name: Setup global git user
+        run: |
+          # For nexus create app flow which will make an init commit
+          git config --global user.name prisma-labs
+          git config --global user.email labs@prisma.io
+      - run: yarn -s test system/${{matrix.test-case}}

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -18,9 +18,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile
       - run: yarn -s build
-      - run: yarn -s test runtime/app runtime/schema/settings lib/build runtime/schema/index lib/nexus-schema-backing-types lib/graphql-client runtime/server runtime/schema/settings-mapper lib/plugin lib/add-to-context-extractor lib/glocal lib/layout
-      # todo
-      # lib/watcher
+      - run: yarn -s test runtime/app runtime/schema/settings lib/build runtime/schema/index lib/nexus-schema-backing-types lib/graphql-client runtime/server runtime/schema/settings-mapper lib/plugin lib/add-to-context-extractor lib/glocal lib/layout lib/watcher
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
     "prompts": "^2.3.0",
     "rxjs": "^6.5.4",
     "simple-git": "^2.0.0",
+    "slash": "^3.0.0",
     "strip-ansi": "^6.0.0",
     "ts-morph": "^7.1.0",
     "ts-node": "^8.10.1",
     "tslib": "^2.0.0",
     "type-fest": "^0.15.0",
-    "typescript": "3.9.x",
-    "upath": "^1.2.0"
+    "typescript": "3.9.x"
   },
   "devDependencies": {
     "@prisma-labs/prettier-config": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "ts-node": "^8.10.1",
     "tslib": "^2.0.0",
     "type-fest": "^0.15.0",
-    "typescript": "3.9.x"
+    "typescript": "3.9.x",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "@prisma-labs/prettier-config": "0.1.0",

--- a/src/lib/test-context/fs.ts
+++ b/src/lib/test-context/fs.ts
@@ -1,5 +1,6 @@
 import * as FS from 'fs-jetpack'
 import { FSJetpack } from 'fs-jetpack/types'
+import * as UPath from 'upath'
 import { createContributor } from './compose-create'
 
 export type FsDeps = {
@@ -8,6 +9,14 @@ export type FsDeps = {
 
 export type FsContribution = {
   fs: FSJetpack
+  /**
+   * Turn given relative path into absolute one.
+   *
+   * Relative to the curerntly setup tmpDir.
+   *
+   * Path is normalized to posix meaning e.g. `C:\a\b\c` becomes `C:/a/b/c`.
+   */
+  path(...relativePath: string[]): string
 }
 
 /**
@@ -16,7 +25,14 @@ export type FsContribution = {
  */
 export const fs = () =>
   createContributor<FsDeps, FsContribution>((ctx) => {
+    const fs = FS.cwd(ctx.tmpDir)
+
+    function path(...relativePath: string[]) {
+      return UPath.normalize(fs.path(...relativePath))
+    }
+
     return {
-      fs: FS.cwd(ctx.tmpDir),
+      fs,
+      path,
     }
   })

--- a/src/lib/test-context/fs.ts
+++ b/src/lib/test-context/fs.ts
@@ -1,6 +1,6 @@
 import * as FS from 'fs-jetpack'
 import { FSJetpack } from 'fs-jetpack/types'
-import * as UPath from 'upath'
+import slash from 'slash'
 import { createContributor } from './compose-create'
 
 export type FsDeps = {
@@ -28,15 +28,7 @@ export const fs = () =>
     const fs = FS.cwd(ctx.tmpDir)
 
     function path(...relativePath: string[]) {
-      console.log(relativePath)
-      console.log(fs.path())
-      console.log(fs.cwd())
-      console.log(fs.path(...relativePath))
-      console.log(fs.path(...relativePath).replace(/\\/g, '\\\\'))
-      console.log(UPath.normalize(fs.path(...relativePath)))
-      console.log(UPath.normalize(fs.path(...relativePath).replace(/\\/g, '\\\\')))
-      // return UPath.normalize(fs.path(...relativePath))
-      return fs.path(...relativePath).replace(/\\/g, '/')
+      return slash(fs.path(...relativePath))
     }
 
     return {
@@ -44,5 +36,3 @@ export const fs = () =>
       path,
     }
   })
-
-console.log(UPath.normalize('C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\7705495513157834\\entrypoint'))

--- a/src/lib/test-context/fs.ts
+++ b/src/lib/test-context/fs.ts
@@ -34,6 +34,7 @@ export const fs = () =>
       console.log(fs.path(...relativePath))
       console.log(fs.path(...relativePath).replace(/\\/g, '\\\\'))
       console.log(UPath.normalize(fs.path(...relativePath)))
+      console.log(UPath.normalize(fs.path(...relativePath).replace(/\\/g, '\\\\')))
       return UPath.normalize(fs.path(...relativePath))
     }
 
@@ -42,5 +43,3 @@ export const fs = () =>
       path,
     }
   })
-
-console.log(UPath.normalize('C:\\a\\b'))

--- a/src/lib/test-context/fs.ts
+++ b/src/lib/test-context/fs.ts
@@ -35,7 +35,8 @@ export const fs = () =>
       console.log(fs.path(...relativePath).replace(/\\/g, '\\\\'))
       console.log(UPath.normalize(fs.path(...relativePath)))
       console.log(UPath.normalize(fs.path(...relativePath).replace(/\\/g, '\\\\')))
-      return UPath.normalize(fs.path(...relativePath))
+      // return UPath.normalize(fs.path(...relativePath))
+      return fs.path(...relativePath).replace(/\\/g, '/')
     }
 
     return {
@@ -43,3 +44,5 @@ export const fs = () =>
       path,
     }
   })
+
+console.log(UPath.normalize('C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\7705495513157834\\entrypoint'))

--- a/src/lib/test-context/fs.ts
+++ b/src/lib/test-context/fs.ts
@@ -28,6 +28,12 @@ export const fs = () =>
     const fs = FS.cwd(ctx.tmpDir)
 
     function path(...relativePath: string[]) {
+      console.log(relativePath)
+      console.log(fs.path())
+      console.log(fs.cwd())
+      console.log(fs.path(...relativePath))
+      console.log(fs.path(...relativePath).replace(/\\/g, '\\\\'))
+      console.log(UPath.normalize(fs.path(...relativePath)))
       return UPath.normalize(fs.path(...relativePath))
     }
 
@@ -36,3 +42,5 @@ export const fs = () =>
       path,
     }
   })
+
+console.log(UPath.normalize('C:\\a\\b'))

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -302,7 +302,7 @@ it.only('does not watch node_modules, even if required', async () => {
     },
   })
   ctx.write({
-    'entrypoint.js': `require('${ctx.fs.path('node_modules', 'some_file.js')}')`,
+    'entrypoint.js': `require('${ctx.path('node_modules/some_file.js')}')`,
     node_modules: {
       'some_file.js': `process.stdout.write('test')`,
     },

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -289,7 +289,7 @@ it('handles lots of restarts', async () => {
 
 it('does not watch node_modules, even if required', async () => {
   const { bufferedEvents } = await testSimpleCase({
-    entrypoint: `require('${ctx.fs.path('node_modules', 'some_file.js')}')`,
+    entrypoint: `require('${ctx.path('node_modules/some_file.js')}')`,
     additionalInitialFiles: {
       node_modules: {
         'some_file.js': `process.stdout.write('test')`,

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -1,10 +1,10 @@
 import * as Lo from 'lodash'
 import * as path from 'path'
-import { createWatcher } from '../../../dist/lib/watcher'
 import * as ExitSystem from '../exit-system'
 import * as TC from '../test-context'
 import { FSSpec, writeFSSpec } from '../testing-utils'
 import { Event } from './types'
+import { createWatcher } from './watcher'
 
 ExitSystem.install()
 process.env.DEBUG = 'true'
@@ -66,7 +66,7 @@ async function testSimpleCase(params: {
   return { bufferedEvents }
 }
 
-it('restarts when a file is changed', async () => {
+it.only('restarts when a file is changed', async () => {
   const { bufferedEvents } = await testSimpleCase({
     entrypoint: `process.stdout.write('hello')`,
     fsUpdate: () => {

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -1,5 +1,4 @@
 import * as Lo from 'lodash'
-import * as path from 'path'
 /**
  * Test agains the built JS so the runner when spawned is using require instead of import syntax which will throw in Node.
  */
@@ -27,7 +26,7 @@ const ctx = TC.create(TC.tmpDir(), TC.fs(), (ctx) => {
       const bufferedEvents: Event[] = []
       await new Promise((res) => setTimeout(res, 10))
       const watcher = await createWatcher({
-        entrypointScript: `require('${path.join(ctx.tmpDir, 'entrypoint')}')`,
+        entrypointScript: `require('${ctx.path('entrypoint')}')`,
         sourceRoot: ctx.tmpDir,
         cwd: ctx.tmpDir,
         plugins: [],

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -19,7 +19,6 @@ const ctx = TC.create(TC.tmpDir(), TC.fs(), (ctx) => {
   return {
     write(vfs: FSSpec) {
       const tmpDir = ctx.tmpDir
-
       writeFSSpec(tmpDir, vfs)
     },
     async createWatcher() {
@@ -286,8 +285,7 @@ it('handles lots of restarts', async () => {
   `)
 })
 
-it('does not watch node_modules, even if required', async () => {
-  console.log(ctx.path('node_modules/some_file.js'))
+it.only('does not watch node_modules, even if required', async () => {
   const { bufferedEvents } = await testSimpleCase({
     entrypoint: `require('${ctx.path('node_modules/some_file.js')}')`,
     additionalInitialFiles: {

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -288,6 +288,7 @@ it('handles lots of restarts', async () => {
 })
 
 it('does not watch node_modules, even if required', async () => {
+  console.log(ctx.path('node_modules/some_file.js'))
   const { bufferedEvents } = await testSimpleCase({
     entrypoint: `require('${ctx.path('node_modules/some_file.js')}')`,
     additionalInitialFiles: {

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -1,10 +1,13 @@
 import * as Lo from 'lodash'
 import * as path from 'path'
+/**
+ * Test agains the built JS so the runner when spawned is using require instead of import syntax which will throw in Node.
+ */
+import { createWatcher } from '../../../dist/lib/watcher'
 import * as ExitSystem from '../exit-system'
 import * as TC from '../test-context'
 import { FSSpec, writeFSSpec } from '../testing-utils'
 import { Event } from './types'
-import { createWatcher } from './watcher'
 
 ExitSystem.install()
 process.env.DEBUG = 'true'

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -285,7 +285,7 @@ it('handles lots of restarts', async () => {
   `)
 })
 
-it.only('does not watch node_modules, even if required', async () => {
+it('does not watch node_modules, even if required', async () => {
   const { bufferedEvents } = await testSimpleCase({
     entrypoint: `require('${ctx.path('node_modules/some_file.js')}')`,
     additionalInitialFiles: {

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -1,6 +1,6 @@
 import * as Lo from 'lodash'
 /**
- * Test agains the built JS so the runner when spawned is using require instead of import syntax which will throw in Node.
+ * Test against the built JS so the runner when spawned is using require instead of import syntax which will throw in Node.
  */
 import { createWatcher } from '../../../dist/lib/watcher'
 import * as ExitSystem from '../exit-system'

--- a/src/lib/watcher/index.spec.ts
+++ b/src/lib/watcher/index.spec.ts
@@ -69,7 +69,7 @@ async function testSimpleCase(params: {
   return { bufferedEvents }
 }
 
-it.only('restarts when a file is changed', async () => {
+it('restarts when a file is changed', async () => {
   const { bufferedEvents } = await testSimpleCase({
     entrypoint: `process.stdout.write('hello')`,
     fsUpdate: () => {

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -81,6 +81,6 @@ async function main() {
   })
 
   console.log('about to eval:\n\n%s', process.env.ENTRYPOINT_SCRIPT)
-  console.log('about to eval fixed:\n\n%s', process.env.ENTRYPOINT_SCRIPT.replace(/\\/, '/'))
-  eval(process.env.ENTRYPOINT_SCRIPT.replace(/\\/, '/'))
+  console.log('about to eval fixed:\n\n%s', process.env.ENTRYPOINT_SCRIPT.replace(/\\/g, '/'))
+  eval(process.env.ENTRYPOINT_SCRIPT.replace(/\\/g, '/'))
 }

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -80,7 +80,5 @@ async function main() {
     IPC.client.senders.moduleImported({ filePath })
   })
 
-  console.log('about to eval:\n\n%s', process.env.ENTRYPOINT_SCRIPT)
-  console.log('about to eval fixed:\n\n%s', process.env.ENTRYPOINT_SCRIPT.replace(/\\/g, '/'))
   eval(process.env.ENTRYPOINT_SCRIPT.replace(/\\/g, '/'))
 }

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -80,5 +80,5 @@ async function main() {
     IPC.client.senders.moduleImported({ filePath })
   })
 
-  eval(process.env.ENTRYPOINT_SCRIPT.replace(/\\/g, '/'))
+  eval(process.env.ENTRYPOINT_SCRIPT)
 }

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -2,10 +2,10 @@
 // for side-effects.
 require('../tty-linker').create().child.install()
 
+import * as DevMode from '../../runtime/dev-mode'
 import { rootLogger } from '../nexus-logger'
 import hook from './hook'
 import * as IPC from './ipc'
-import * as DevMode from '../../runtime/dev-mode'
 
 const log = rootLogger.child('dev').child('runner')
 
@@ -80,5 +80,6 @@ async function main() {
     IPC.client.senders.moduleImported({ filePath })
   })
 
+  console.log('about to eval:\n\n%s', process.env.ENTRYPOINT_SCRIPT)
   eval(process.env.ENTRYPOINT_SCRIPT)
 }

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -81,5 +81,6 @@ async function main() {
   })
 
   console.log('about to eval:\n\n%s', process.env.ENTRYPOINT_SCRIPT)
-  eval(process.env.ENTRYPOINT_SCRIPT)
+  console.log('about to eval fixed:\n\n%s', process.env.ENTRYPOINT_SCRIPT.replace(/\\/, '/'))
+  eval(process.env.ENTRYPOINT_SCRIPT.replace(/\\/, '/'))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6422,7 +6422,7 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@^1.1.1:
+upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==


### PR DESCRIPTION
Technical notes:

TIL:

- https://superuser.com/questions/176388/why-does-windows-use-backslashes-for-paths-and-unix-forward-slashes/176395#176395 via https://github.com/sindresorhus/slash#slash-

Problem:

We were having weird issues with `\`.

[Specifically](https://github.com/graphql-nexus/nexus/runs/816374829#step:6:4):

```
SyntaxError: Octal escape sequences are not allowed in strict mode
```

coming from this LOC in `watcher/runner.ts`:

```ts
eval(process.env.ENTRYPOINT_SCRIPT)
```

When the string to eval was:

```
require('C:\Users\RUNNER~1\AppData\Local\Temp\37742529471191166\entrypoint')
```

I don't know why this did not fail in linux.

Windows treated this string as if the `\` were not escaped, so for example `\377` was treated as octal escape sequence...

I finally realized that:

1. Windows will accept `C:/a/b/c`
2. That TS does this and it is probably to help make things work more smoothly
  So my confusion [in the previous PR](https://github.com/graphql-nexus/nexus/pull/1121#discussion_r446592222) is resolved.
3. Apparently even a best practice given that at least these two _widely_ used libs exist:

- https://github.com/anodynos/upath
- https://github.com/sindresorhus/slash

Chose to use `upath` because I have concluded that we should move away from backslashes by default. If we need them for some case then we'll make the exception then and there. Why:

1. Align with TS
2. Avoid issues like this one in the future