### PR TITLE
refactor(layout): return either on no-modules-or-nexus-module

### DIFF
--- a/src/lib/layout/index.spec.ts
+++ b/src/lib/layout/index.spec.ts
@@ -459,21 +459,17 @@ it('fails if no entrypoint and no nexus modules', async () => {
     },
   })
 
-  await ctx.createLayoutThrow()
+  const res = await ctx.createLayout()
 
-  expect(logs).toMatchInlineSnapshot(`
-    "■ nexus:layout We could not find any modules that imports 'nexus' or app.ts entrypoint
-    ■ nexus:layout Please do one of the following:
-
-      1. Create a file, import { schema } from 'nexus' and write your GraphQL type definitions in it.
-      2. Create an [33mapp.ts[39m file.
-
-
-    --- process.exit(1) ---
-
-    "
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "_tag": "Left",
+      "left": Object {
+        "context": Object {},
+        "type": "no_app_or_schema_modules",
+      },
+    }
   `)
-  expect(mockExit).toHaveBeenCalledWith(1)
 })
 
 describe('nexusModules', () => {
@@ -550,7 +546,7 @@ describe('entrypoint', () => {
   })
 
   it('set app.exists = false if no entrypoint', async () => {
-    await ctx.setup({ 'tsconfig.json': tsconfigSource(), 'graphql.ts': '' })
+    await ctx.setup({ 'tsconfig.json': tsconfigSource(), 'foo.ts': 'import "nexus"' })
     const result = await ctx.createLayoutThrow()
     expect(result.app).toMatchInlineSnapshot(`
           Object {
@@ -605,7 +601,7 @@ describe('entrypoint', () => {
 
 describe('build', () => {
   it(`defaults to .nexus/build`, async () => {
-    await ctx.setup({ 'tsconfig.json': tsconfigSource(), 'graphql.ts': '' })
+    await ctx.setup({ 'tsconfig.json': tsconfigSource(), 'foo.ts': 'import "nexus"' })
     const result = await ctx.createLayoutThrow()
     expect(result).toMatchObject({
       build: {
@@ -623,7 +619,7 @@ describe('build', () => {
           outDir: 'dist',
         },
       }),
-      'graphql.ts': '',
+      'foo.ts': 'import "nexus"',
     })
     const result = await ctx.createLayout2().then(rightOrThrow)
     expect(result).toMatchObject({
@@ -641,7 +637,7 @@ describe('build', () => {
           outDir: 'dist',
         },
       }),
-      'graphql.ts': '',
+      'foo.ts': 'import "nexus"',
     })
     const result = await ctx.createLayoutThrow({ buildOutput: 'custom-output' })
 

--- a/src/lib/layout/index.spec.ts
+++ b/src/lib/layout/index.spec.ts
@@ -24,10 +24,6 @@ afterEach(() => {
   logs = ''
 })
 
-const mockExit = jest.spyOn(process, 'exit').mockImplementation(((n: any) => {
-  logs += `\n\n--- process.exit(${n}) ---\n\n`
-}) as any)
-
 /**
  * Disable logger timeDiff and color to allow snapshot matching
  */

--- a/src/lib/layout/layout.ts
+++ b/src/lib/layout/layout.ts
@@ -10,7 +10,7 @@ import { findFile, isEmptyDir } from '../../lib/fs'
 import { rootLogger } from '../nexus-logger'
 import * as PJ from '../package-json'
 import * as PackageManager from '../package-manager'
-import { exception } from '../utils'
+import { exception, exceptionType } from '../utils'
 import { BuildLayout, getBuildLayout } from './build'
 import { saveDataForChildProcess } from './cache'
 import { readOrScaffoldTsconfig } from './tsconfig'
@@ -190,10 +190,7 @@ export async function create(options?: Options): Promise<Either<Error, Layout>> 
   }
 
   if (scanResult.app.exists === false && scanResult.nexusModules.length === 0) {
-    // todo return left
-    log.error(checks.no_app_or_nexus_modules.explanations.problem)
-    log.error(checks.no_app_or_nexus_modules.explanations.solution)
-    process.exit(1)
+    return left(noAppOrNexusModules({}))
   }
 
   const buildInfo = getBuildLayout(options?.buildOutputDir, scanResult, options?.asBundle)
@@ -268,6 +265,13 @@ const checks = {
     }
   },
 }
+
+const noAppOrNexusModules = exceptionType<'no_app_or_schema_modules', {}>(
+  'no_app_or_schema_modules',
+  checks.no_app_or_nexus_modules.explanations.problem +
+    '\n' +
+    checks.no_app_or_nexus_modules.explanations.solution
+)
 
 /**
  * Find the (optional) app module in the user's project.

--- a/src/lib/layout/layout.ts
+++ b/src/lib/layout/layout.ts
@@ -3,6 +3,7 @@ import Chalk from 'chalk'
 import { stripIndent } from 'common-tags'
 import { Either, isLeft, left, right } from 'fp-ts/lib/Either'
 import * as FS from 'fs-jetpack'
+import * as OS from 'os'
 import * as Path from 'path'
 import * as ts from 'ts-morph'
 import type { ParsedCommandLine } from 'typescript'
@@ -269,7 +270,7 @@ const checks = {
 const noAppOrNexusModules = exceptionType<'no_app_or_schema_modules', {}>(
   'no_app_or_schema_modules',
   checks.no_app_or_nexus_modules.explanations.problem +
-    '\n' +
+    OS.EOL +
     checks.no_app_or_nexus_modules.explanations.solution
 )
 


### PR DESCRIPTION
New look, we no longer control logging problem and solution as two separate logs, is fine:

![image](https://user-images.githubusercontent.com/284476/85969659-5295bf80-b996-11ea-9c3b-b25b9b3c93c9.png)
