### PR TITLE
feat(server): disable graphql introspection in production

### DIFF
--- a/src/runtime/server/handler-graphql.spec.ts
+++ b/src/runtime/server/handler-graphql.spec.ts
@@ -162,6 +162,9 @@ function createHandler(...types: any) {
     }),
     () => {
       return {}
+    },
+    {
+      introspection: true,
     }
   )
 }

--- a/src/runtime/server/handler-graphql.ts
+++ b/src/runtime/server/handler-graphql.ts
@@ -1,5 +1,15 @@
 import { Either, isLeft, left, right, toError, tryCatch } from 'fp-ts/lib/Either'
-import { execute, getOperationAST, GraphQLSchema, parse, Source, validate } from 'graphql'
+import {
+  execute,
+  getOperationAST,
+  GraphQLSchema,
+  parse,
+  Source,
+  validate,
+  ValidationContext,
+  FieldNode,
+  GraphQLError,
+} from 'graphql'
 import { IncomingMessage } from 'http'
 import createError, { HttpError } from 'http-errors'
 import url from 'url'
@@ -7,7 +17,15 @@ import { parseBody } from './parse-body'
 import { ContextCreator, NexusRequestHandler } from './server'
 import { sendError, sendErrorData, sendSuccess } from './utils'
 
-type CreateHandler = (schema: GraphQLSchema, createContext: ContextCreator) => NexusRequestHandler
+type Settings = {
+  introspection: boolean
+}
+
+type CreateHandler = (
+  schema: GraphQLSchema,
+  createContext: ContextCreator,
+  settings: Settings
+) => NexusRequestHandler
 
 type GraphQLParams = {
   query: null | string
@@ -16,10 +34,26 @@ type GraphQLParams = {
   raw: boolean
 }
 
+const NoIntrospection = (context: ValidationContext) => ({
+  Field(node: FieldNode) {
+    if (node.name.value === '__schema' || node.name.value === '__type') {
+      context.reportError(
+        new GraphQLError(
+          'GraphQL introspection is not allowed by Nexus, but the query contained __schema or __type. To enable introspection, pass introspection: true to Nexus graphql settings in production',
+          [node]
+        )
+      )
+    }
+  },
+})
+
 /**
  * Create a handler for graphql requests.
  */
-export const createRequestHandlerGraphQL: CreateHandler = (schema, createContext) => async (req, res) => {
+export const createRequestHandlerGraphQL: CreateHandler = (schema, createContext, settings) => async (
+  req,
+  res
+) => {
   const errParams = await getGraphQLParams(req)
 
   if (isLeft(errParams)) {
@@ -42,7 +76,8 @@ export const createRequestHandlerGraphQL: CreateHandler = (schema, createContext
 
   const documentAST = errDocumentAST.right
 
-  const validationFailures = validate(schema, documentAST)
+  const validationRules = !settings.introspection ? [NoIntrospection] : []
+  const validationFailures = validate(schema, documentAST, validationRules)
 
   if (validationFailures.length > 0) {
     // todo lots of rich info for clients in here, expose it to them

--- a/src/runtime/server/handler-graphql.ts
+++ b/src/runtime/server/handler-graphql.ts
@@ -7,6 +7,7 @@ import {
   Source,
   validate,
   ValidationContext,
+  specifiedRules,
   FieldNode,
   GraphQLError,
 } from 'graphql'
@@ -76,8 +77,11 @@ export const createRequestHandlerGraphQL: CreateHandler = (schema, createContext
 
   const documentAST = errDocumentAST.right
 
-  const validationRules = !settings.introspection ? [NoIntrospection] : []
-  const validationFailures = validate(schema, documentAST, validationRules)
+  let rules = specifiedRules
+  if (!settings.introspection) {
+    rules = [...rules, NoIntrospection]
+  }
+  const validationFailures = validate(schema, documentAST, rules)
 
   if (validationFailures.length > 0) {
     // todo lots of rich info for clients in here, expose it to them

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -74,7 +74,11 @@ export function create(appState: AppState) {
         return (
           assembledGuard(appState, 'app.server.handlers.graphql', () => {
             return wrapHandlerWithErrorHandling(
-              createRequestHandlerGraphQL(appState.assembled!.schema, appState.assembled!.createContext)
+              createRequestHandlerGraphQL(
+                appState.assembled!.schema,
+                appState.assembled!.createContext,
+                settings.data.graphql
+              )
             )
           }) ?? noop
         )
@@ -106,7 +110,7 @@ export function create(appState: AppState) {
           loadedRuntimePlugins
         )
 
-        const graphqlHandler = createRequestHandlerGraphQL(schema, createContext)
+        const graphqlHandler = createRequestHandlerGraphQL(schema, createContext, settings.data.graphql)
 
         express.post(settings.data.path, wrapHandlerWithErrorHandling(graphqlHandler))
         express.get(settings.data.path, wrapHandlerWithErrorHandling(graphqlHandler))

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -8,6 +8,10 @@ export type PlaygroundSettings = {
   path?: string
 }
 
+export type GraphqlSettings = {
+  introspection?: boolean
+}
+
 export type SettingsInput = {
   /**
    * todo
@@ -50,17 +54,26 @@ export type SettingsInput = {
     path: string
     playgroundPath?: string
   }) => void
+  /**
+   * todo
+   */
+  graphql?: GraphqlSettings
 }
 
-export type SettingsData = Omit<Utils.DeepRequired<SettingsInput>, 'host' | 'playground'> & {
+export type SettingsData = Omit<Utils.DeepRequired<SettingsInput>, 'host' | 'playground' | 'graphql'> & {
   host: string | undefined
   playground: false | Required<PlaygroundSettings>
+  graphql: Required<GraphqlSettings>
 }
 
 export const defaultPlaygroundPath = '/'
 
 export const defaultPlaygroundSettings: () => Readonly<Required<PlaygroundSettings>> = () => ({
   path: defaultPlaygroundPath,
+})
+
+export const defaultGraphqlSettings: () => Readonly<Required<GraphqlSettings>> = () => ({
+  introspection: process.env.NODE_ENV === 'production' ? false : true,
 })
 
 /**
@@ -86,6 +99,7 @@ export const defaultSettings: () => Readonly<SettingsData> = () => {
     },
     playground: process.env.NODE_ENV === 'production' ? false : defaultPlaygroundSettings(),
     path: '/graphql',
+    graphql: defaultGraphqlSettings(),
   }
 }
 
@@ -121,6 +135,10 @@ export function playgroundSettings(settings: SettingsInput['playground']): Setti
   }
 }
 
+export function graphqlSettings(settings: SettingsInput['graphql']): SettingsData['graphql'] {
+  return { ...defaultGraphqlSettings(), ...settings }
+}
+
 function validateGraphQLPath(path: string): string {
   let outputPath = path
 
@@ -147,6 +165,7 @@ export function changeSettings(state: SettingsData, newSettings: SettingsInput):
   state.path = validateGraphQLPath(updatedSettings.path)
   state.port = updatedSettings.port
   state.startMessage = updatedSettings.startMessage
+  state.graphql = graphqlSettings(updatedSettings.graphql)
 }
 
 export function createServerSettingsManager() {


### PR DESCRIPTION
closes #1168

Graphql instrospection is now disabled by default in production.

A new setting can control this behavior:

```typescript
settings.change({
  server: {
    graphql: {
      introspection: true
    }
  }
});
```