### PR TITLE
fix: display stack traces on graphql errors

### DIFF
--- a/src/runtime/server/error-formatter.ts
+++ b/src/runtime/server/error-formatter.ts
@@ -1,0 +1,100 @@
+import { GraphQLError, Source, SourceLocation } from 'graphql'
+import stripAnsi from 'strip-ansi'
+import { log } from './logger'
+
+const resolverLogger = log.child('graphql')
+
+export function errorFormatter(graphQLError: GraphQLError) {
+  const colorlessMessage = stripAnsi(graphQLError.message)
+
+  if (process.env.NEXUS_STAGE === 'dev') {
+    resolverLogger.error(graphQLError.message)
+
+    if (graphQLError.source && graphQLError.locations) {
+      console.log(indent(printSourceLocation(graphQLError.source, graphQLError.locations[0]), 5))
+      if (graphQLError.stack) {
+        console.log(graphQLError.stack)
+      }
+    }
+  } else {
+    graphQLError.message = colorlessMessage
+    resolverLogger.error('An exception occurred in one of your resolver', {
+      error: {
+        ...graphQLError,
+        stack: graphQLError.stack
+      },
+    })
+  }
+
+  graphQLError.message = colorlessMessage
+
+  return graphQLError
+}
+
+/**
+ * Render a helpful description of the location in the GraphQL Source document.
+ * Modified version from graphql-js
+ */
+export function printSourceLocation(source: Source, sourceLocation: SourceLocation): string {
+  const firstLineColumnOffset = source.locationOffset.column - 1
+  const body = whitespace(firstLineColumnOffset) + source.body
+
+  const lineIndex = sourceLocation.line - 1
+  const lineOffset = source.locationOffset.line - 1
+  const lineNum = sourceLocation.line + lineOffset
+
+  const columnOffset = sourceLocation.line === 1 ? firstLineColumnOffset : 0
+  const columnNum = sourceLocation.column + columnOffset
+
+  const lines = body.split(/\r\n|[\n\r]/g)
+  const locationLine = lines[lineIndex]
+
+  // Special case for minified documents
+  if (locationLine.length > 120) {
+    const subLineIndex = Math.floor(columnNum / 80)
+    const subLineColumnNum = columnNum % 80
+    const subLines = []
+    for (let i = 0; i < locationLine.length; i += 80) {
+      subLines.push(locationLine.slice(i, i + 80))
+    }
+
+    return printPrefixedLines([
+      [`${lineNum}`, subLines[0]],
+      ...subLines.slice(1, subLineIndex + 1).map((subLine) => ['', subLine]),
+      [' ', whitespace(subLineColumnNum - 1) + '^'],
+      ['', subLines[subLineIndex + 1]],
+    ])
+  }
+
+  return printPrefixedLines([
+    // Lines specified like this: ["prefix", "string"],
+    [`${lineNum - 1}`, lines[lineIndex - 1]],
+    [`${lineNum}`, locationLine],
+    ['', whitespace(columnNum - 1) + '^'],
+    [`${lineNum + 1}`, lines[lineIndex + 1]],
+  ])
+}
+
+function printPrefixedLines(lines: Array<string[]>): string {
+  const existingLines = lines.filter(([_, line]) => line !== undefined)
+
+  const padLen = Math.max(...existingLines.map(([prefix]) => prefix.length))
+  return existingLines
+    .map(([prefix, line]) => leftPad(padLen, prefix) + (line ? ' | ' + line : ' |'))
+    .join('\n')
+}
+
+function whitespace(len: number): string {
+  return Array(len + 1).join(' ')
+}
+
+function leftPad(len: number, str: string): string {
+  return whitespace(len - str.length) + str
+}
+
+function indent(str: string, len: number, char: string = ' ') {
+  return str
+    .split('\n')
+    .map((s) => char.repeat(len) + s)
+    .join('\n')
+}

--- a/src/runtime/server/handler-graphql.spec.ts
+++ b/src/runtime/server/handler-graphql.spec.ts
@@ -3,6 +3,7 @@ import { IncomingMessage, ServerResponse } from 'http'
 import { Socket } from 'net'
 import { createRequestHandlerGraphQL } from './handler-graphql'
 import { NexusRequestHandler } from './server'
+import { errorFormatter } from './error-formatter'
 
 let handler: NexusRequestHandler
 let socket: Socket
@@ -165,6 +166,7 @@ function createHandler(...types: any) {
     },
     {
       introspection: true,
+      errorFormatterFn: errorFormatter,
     }
   )
 }

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -1,15 +1,15 @@
 import createExpress, { Express } from 'express'
-import { GraphQLSchema } from 'graphql'
+import { GraphQLError, GraphQLSchema } from 'graphql'
 import * as HTTP from 'http'
 import { HttpError } from 'http-errors'
 import * as Net from 'net'
-import stripAnsi from 'strip-ansi'
 import * as Plugin from '../../lib/plugin'
 import { httpClose, httpListen, MaybePromise, noop } from '../../lib/utils'
 import { AppState } from '../app'
 import * as DevMode from '../dev-mode'
 import { ContextContributor } from '../schema/schema'
 import { assembledGuard } from '../utils'
+import { errorFormatter } from './error-formatter'
 import { createRequestHandlerGraphQL } from './handler-graphql'
 import { createRequestHandlerPlayground } from './handler-playground'
 import { log } from './logger'
@@ -73,12 +73,13 @@ export function create(appState: AppState) {
       get graphql() {
         return (
           assembledGuard(appState, 'app.server.handlers.graphql', () => {
-            return wrapHandlerWithErrorHandling(
-              createRequestHandlerGraphQL(
-                appState.assembled!.schema,
-                appState.assembled!.createContext,
-                settings.data.graphql
-              )
+            return createRequestHandlerGraphQL(
+              appState.assembled!.schema,
+              appState.assembled!.createContext,
+              {
+                ...settings.data.graphql,
+                errorFormatterFn: errorFormatter,
+              }
             )
           }) ?? noop
         )
@@ -110,10 +111,13 @@ export function create(appState: AppState) {
           loadedRuntimePlugins
         )
 
-        const graphqlHandler = createRequestHandlerGraphQL(schema, createContext, settings.data.graphql)
+        const graphqlHandler = createRequestHandlerGraphQL(schema, createContext, {
+          ...settings.data.graphql,
+          errorFormatterFn: errorFormatter,
+        })
 
-        express.post(settings.data.path, wrapHandlerWithErrorHandling(graphqlHandler))
-        express.get(settings.data.path, wrapHandlerWithErrorHandling(graphqlHandler))
+        express.post(settings.data.path, graphqlHandler)
+        express.get(settings.data.path, graphqlHandler)
 
         return { createContext }
       },
@@ -159,18 +163,15 @@ const wrapHandlerWithErrorHandling = (handler: NexusRequestHandler): NexusReques
     await handler(req, res)
     if (res.statusCode !== 200 && (res as any).error) {
       const error: HttpError = (res as any).error
-      const colorlessMessage = stripAnsi(error.message)
+      const graphqlErrors: GraphQLError[] = error.graphqlErrors
 
-      if (process.env.NEXUS_STAGE === 'dev') {
-        resolverLogger.error(error.stack ?? error.message)
+      if (graphqlErrors.length > 0) {
+        graphqlErrors.forEach(errorFormatter)
       } else {
-        resolverLogger.error('An exception occured in one of your resolver', {
-          error: error.stack ? stripAnsi(error.stack) : colorlessMessage,
+        log.error(error.message, {
+          error,
         })
       }
-
-      // todo bring back payload sanitization for data sent to clients
-      // error.message = colorlessMessage
     }
   }
 }

--- a/src/runtime/server/utils.ts
+++ b/src/runtime/server/utils.ts
@@ -9,7 +9,7 @@ export function sendSuccess(res: ServerResponse, data: object): void {
 
 export function sendErrorData(res: ServerResponse, e: HttpError): void {
   ;(res as any).error = e
-  sendJSON(res, e.status, e.name, e.headers ?? {}, e.data)
+  sendJSON(res, e.status, e.name, e.headers ?? {}, e.graphqlErrors)
 }
 
 export function sendError(res: ServerResponse, e: HttpError): void {


### PR DESCRIPTION
closes #1186, related to #1182

#### Rendering

In dev (displaying the message and repeating the stack is based on [a suggestion from Ivan Goncharov here](https://github.com/graphql/graphql-js/issues/2215#issuecomment-540054812)):

![image](https://user-images.githubusercontent.com/25233379/86899700-a5941300-c10a-11ea-9909-0ce1a35c4012.png)

In production (structured logs):

![image](https://user-images.githubusercontent.com/25233379/86899720-ab89f400-c10a-11ea-8545-fe22c0f8d52a.png)

#### TODO

- [ ] docs
  - [ ] jsdoc
  - [ ] website api
  - [ ] website guides
  - [ ] website tutorial
- [ ] tests
