### PR TITLE
feat(settings): server.playground.enabled

### DIFF
--- a/src/runtime/server/handler-graphql.ts
+++ b/src/runtime/server/handler-graphql.ts
@@ -2,11 +2,11 @@ import { GraphQLError, GraphQLFormattedError, GraphQLSchema } from 'graphql'
 import { ApolloServerless } from './apollo-server'
 import { log } from './logger'
 import { ContextCreator, NexusRequestHandler } from './server'
-import { PlaygroundSettings } from './settings'
+import { PlaygroundInput } from './settings'
 
 type Settings = {
   introspection: boolean
-  playground: false | PlaygroundSettings
+  playground: false | PlaygroundInput
   path: string
   errorFormatterFn(graphqlError: GraphQLError): GraphQLFormattedError
 }
@@ -30,5 +30,5 @@ export const createRequestHandlerGraphQL: CreateHandler = (schema, createContext
     playground: settings.playground,
   })
 
-  return server.createHandler({ path: settings.path  })
+  return server.createHandler({ path: settings.path })
 }

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -108,9 +108,10 @@ export function create(appState: AppState) {
           introspection: settings.data.graphql.introspection,
           formatError: errorFormatter,
           logger: resolverLogger,
-          playground: settings.data.playground
+          playground: settings.data.playground.enabled
             ? {
                 endpoint: settings.data.path,
+                settings: settings.data.playground.settings,
               }
             : false,
         })

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -7,7 +7,27 @@ import { log as serverLogger } from './logger'
 const log = serverLogger.child('settings')
 
 export type PlaygroundInput = {
+  /**
+   * Should the [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) be hosted by the server?
+   *
+   * @dynamicDefault
+   *
+   * - If not production then `true`
+   * - Otherwise `false`
+   *
+   * @remarks
+   *
+   * GraphQL Playground is useful during development as a visual client to interact with your API. In
+   * production, without some kind of security/access control, you will almost
+   * certainly want it disabled.
+   */
   enabled?: boolean
+
+  // todo consider de-nesting the settings field
+
+  /**
+   * Configure the settings of the GraphQL Playground app itself.
+   */
   settings?: Omit<Partial<Exclude<PlaygroundRenderPageOptions['settings'], undefined>>, 'general.betaUpdates'>
 }
 
@@ -25,18 +45,22 @@ export type SettingsInput = {
    */
   host?: string | undefined
   /**
-   * Should GraphQL Playground be hosted by the server?
+   * Configure the [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) hosted by the server.
    *
-   * @default `false` in production, `{ path: '/' }` otherwise
+   * - Pass `true` as shorthand for  `{ enabled: true }`
+   * - Pass `false` as shorthand for `{ enabled: false }`
+   * - Pass an object to configure
+   *
+   * @dynamicDefault
+   *
+   * - If not production then `true`
+   * - Otherwise `false`
    *
    * @remarks
    *
-   * Useful during development as a visual client to interact with your API. In
+   * GraphQL Playground is useful during development as a visual client to interact with your API. In
    * production, without some kind of security/access control, you will almost
-   * certainly want this disabled.
-   *
-   * To learn more about GraphQL Playgorund see
-   * https://github.com/prisma-labs/graphql-playground
+   * certainly want it disabled.
    */
   playground?: boolean | PlaygroundInput
   /**

--- a/src/runtime/server/settings.ts
+++ b/src/runtime/server/settings.ts
@@ -173,7 +173,7 @@ export type SettingsData = Omit<
   host: string | undefined
   playground: Required<PlaygroundInput>
   graphql: Required<GraphqlInput>
-  cors: boolean | CorsSettings
+  cors: CorsSettings
 }
 
 export const defaultPlaygroundPath = '/graphql'
@@ -220,7 +220,7 @@ export const defaultSettings: () => Readonly<SettingsData> = () => {
     },
     playground: defaultPlaygroundSettings(),
     path: '/graphql',
-    cors: false,
+    cors: { enabled: false },
     graphql: defaultGraphqlSettings(),
   }
 }
@@ -262,16 +262,15 @@ function validateGraphQLPath(path: string): string {
   return outputPath
 }
 
-export function corsSettings(newSettings: SettingsInput['cors']): SettingsData['cors'] {
-  if (typeof newSettings === 'boolean') {
-    return newSettings
+export function processCorsInput(
+  current: SettingsData['cors'],
+  input: NonNullable<SettingsInput['cors']>
+): SettingsData['cors'] {
+  if (typeof input === 'boolean') {
+    return { enabled: input }
   }
 
-  if (!newSettings || newSettings.enabled === false) {
-    return false
-  }
-
-  return newSettings
+  return defaults({}, input, current)
 }
 
 /**
@@ -293,7 +292,9 @@ export function changeSettings(current: SettingsData, input: SettingsInput): voi
   if (!isUndefined(input.startMessage)) {
     current.startMessage = input.startMessage
   }
-  current.cors = corsSettings(input.cors)
+  if (!isUndefined(input.cors)) {
+    current.cors = processCorsInput(current.cors, input.cors)
+  }
 }
 
 /**

--- a/website/content/040-api/01-nexus/04-settings.mdx
+++ b/website/content/040-api/01-nexus/04-settings.mdx
@@ -54,6 +54,10 @@ Change your app's current settings. This is an additive API meaning it can be ca
 boolean | PlaygroundSettings
 ```
 
+- Passing `boolean` is shorthand for `{ enabled: true | false }`
+
+#### `server.playground.enabled`
+
 Should the app expose a [GraphQL Playground](https://github.com/prisma-labs/graphql-playground) to clients?
 
 _Default_
@@ -64,18 +68,18 @@ _Default_
 
 ```
 {
-  'request.credentials': string;
-  'tracing.hideTracingResponse': boolean;
+  'request.credentials'?: string;
+  'tracing.hideTracingResponse'?: boolean;
   'queryPlan.hideQueryPlanResponse'?: boolean;
-  'editor.theme': Theme;
-  'editor.cursorShape': CursorShape;
-  'editor.reuseHeaders': boolean;
-  'editor.fontSize': number;
-  'editor.fontFamily': string;
+  'editor.theme'?: Theme;
+  'editor.cursorShape'?: CursorShape;
+  'editor.reuseHeaders'?: boolean;
+  'editor.fontSize'?: number;
+  'editor.fontFamily'?: string;
 }
 ```
 
-Configure the Playground settings
+Configure the Playground UI settings
 
 _Default_
 


### PR DESCRIPTION
Use the .enabled pattern for playground.

Also fixes some settings bugs under incremental usage. Previously
multiple partial sets of playground settings would result in previous
playground settings getting blown away.

Also changes the settings data representation of cors to be based on nested enabled property.

- [x] docs
  - [x] jsdoc
  - [x] website api
- [ ] tests

