### PR TITLE
feat(context): extract type imports from generics

### DIFF
--- a/src/lib/add-to-context-extractor/extractor.spec.ts
+++ b/src/lib/add-to-context-extractor/extractor.spec.ts
@@ -753,7 +753,56 @@ describe('top-level union types', () => {
 })
 
 describe('generics', () => {
-  it('imports referenced types in generic position', () => {
+  it('types that are referenced in the generic of a type alias get extracted as type imports', () => {
+    expect(
+      extract(`
+          interface Foo1 {}
+          interface Foo2 {}
+          interface Foo3 {}
+          interface Foo4 {}
+          type Bar<T> = {}
+          schema.addToContext(() => {
+            return { } as { a: Bar<Foo1>; b: number | Bar<Foo2>; c: Foo3 & Bar<Foo4> }
+          })
+        `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "typeImports": Array [
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Bar",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo1",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo2",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo3",
+          },
+        ],
+        "types": Array [
+          Object {
+            "kind": "literal",
+            "value": "{ a: Bar<Foo1>; b: number | Bar<Foo2>; c: Foo3; }",
+          },
+        ],
+      }
+    `)
+  })
+  it('types that are referenced in the generic of an interface get extracted as type imports', () => {
     expect(
       extract(`
           interface Foo1 {}

--- a/src/lib/add-to-context-extractor/extractor.spec.ts
+++ b/src/lib/add-to-context-extractor/extractor.spec.ts
@@ -752,6 +752,64 @@ describe('top-level union types', () => {
   })
 })
 
+describe('generics', () => {
+  it('imports referenced types in generic position', () => {
+    expect(
+      extract(`
+          interface Foo1 {}
+          interface Foo2 {}
+          interface Foo3 {}
+          interface Foo4 {}
+          interface Bar<T> {}
+          schema.addToContext(() => {
+            return { } as { a: Bar<Foo1>; b: number | Bar<Foo2>; c: Foo3 & Bar<Foo4> }
+          })
+        `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "typeImports": Array [
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Bar",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo1",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo2",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo3",
+          },
+          Object {
+            "isExported": false,
+            "isNode": false,
+            "modulePath": "/src/a",
+            "name": "Foo4",
+          },
+        ],
+        "types": Array [
+          Object {
+            "kind": "literal",
+            "value": "{ a: Bar<Foo1>; b: number | Bar<Foo2>; c: Foo3 & Bar<Foo4>; }",
+          },
+        ],
+      }
+    `)
+  })
+})
+
 // This test is only relevant so long as we're using the TS type to string
 // function
 // todo cannot find a case that leads to TS truncating...

--- a/src/lib/add-to-context-extractor/extractor.ts
+++ b/src/lib/add-to-context-extractor/extractor.ts
@@ -225,7 +225,11 @@ function captureTypeImport(registry: Index<TypeImportInfo>, t: tsm.Type | tsm.Ty
    */
 
   types.forEach((t) => {
-    t.getTypeArguments().forEach((typeArg) => {
+    log.trace('checking type for type arguments', { text: t.getText() })
+    //todo only call alias type arguments method if type is an alias?
+    const typeArguments = [...t.getAliasTypeArguments(), ...t.getTypeArguments()]
+    typeArguments.forEach((typeArg) => {
+      log.trace('extracting import info for generic', { text: typeArg.getText() })
       const info = extractTypeImportInfoFromType(typeArg)
       if (info) {
         registry[info.name] = info


### PR DESCRIPTION
closes #1299

The first use-case for this came from manually using Prisma with Nexus, a new example https://github.com/graphql-nexus/examples/pull/66

#### TODO

- [x] tests