### PR TITLE
chore(docs): Update schema.enum to schema.enumType in guide

### DIFF
--- a/website/content/020-guides/02-schema.mdx
+++ b/website/content/020-guides/02-schema.mdx
@@ -196,7 +196,7 @@ Enum types are a scalar with a finite set of allowed values. They can be used as
 
 
 ```ts
-schema.enum({
+schema.enumType({
   name: 'Alpha',
   members: ['Zeta', 'Yolo'],
 })


### PR DESCRIPTION
Noticed this, not sure if it's a typo or based on an older API.