### PR TITLE
improve: expose projectRoot setting in createTestContext

### DIFF
--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -40,6 +40,7 @@ export interface CreateTestContextOptions {
    * You should typically use this if you're using `nexus dev --entrypoint` or `nexus build --entrypoint`.
    */
   entrypointPath?: string
+  projectRoot?: string
 }
 
 /**
@@ -68,7 +69,7 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
   process.env.NEXUS_STAGE = 'dev'
 
   // todo figure out some caching system here, e.g. imagine jest --watch mode
-  const layout = rightOrFatal(await Layout.create({ entrypointPath: opts?.entrypointPath }))
+  const layout = rightOrFatal(await Layout.create({ entrypointPath: opts?.entrypointPath, projectRoot: opts?.projectRoot }))
   const pluginManifests = await PluginWorktime.getUsedPlugins(layout)
   const randomPort = await getPort({ port: getPort.makeRange(4000, 6000) })
   const privateApp = app as PrivateApp

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -24,7 +24,7 @@ export interface TestContextCore {
 }
 
 declare global {
-  interface NexusTestContextApp extends TestContextAppCore {}
+  interface NexusTestContextApp extends TestContextAppCore { }
 
   interface NexusTestContextRoot {
     app: NexusTestContextApp
@@ -40,6 +40,13 @@ export interface CreateTestContextOptions {
    * You should typically use this if you're using `nexus dev --entrypoint` or `nexus build --entrypoint`.
    */
   entrypointPath?: string
+  /**
+   * Nexus usually determines the project root by the first `package.json` found while traversing up the file system.
+   * In some cases, e.g. usage in a monorepo, this might not always be correct.
+   * For those cases, you can specify the `projectRoot` manually.
+   *
+   * Example: `await createTestContext({ projectRoot: path.join(__dirname, '../..') })`
+   */
   projectRoot?: string
 }
 
@@ -77,7 +84,7 @@ export async function createTestContext(opts?: CreateTestContextOptions): Promis
   const forcedServerSettings = {
     port: randomPort,
     playground: false, // Disable playground during tests
-    startMessage() {}, // Make server silent
+    startMessage() { }, // Make server silent
   }
 
   // todo remove these settings hacks once we have https://github.com/graphql-nexus/nexus/issues/758

--- a/website/content/040-api/02-nexus-testing.mdx
+++ b/website/content/040-api/02-nexus-testing.mdx
@@ -54,6 +54,13 @@ export interface CreateTestContextOptions {
    * You should typically use this if you're using `nexus dev --entrypoint` or `nexus build --entrypoint`.
    */
   entrypointPath?: string
+  /**
+   * Nexus usually determines the project root by the first `package.json` found while traversing up the file system.
+   * In some cases, e.g. usage in a monorepo, this might not always be correct.
+   * For those cases, you can specify the `projectRoot` manually.
+   * 
+   * Example: `await createTestContext({ projectRoot: path.join(__dirname, '../..') })`
+   */
   projectRoot?: string
 }
 ```

--- a/website/content/040-api/02-nexus-testing.mdx
+++ b/website/content/040-api/02-nexus-testing.mdx
@@ -54,6 +54,7 @@ export interface CreateTestContextOptions {
    * You should typically use this if you're using `nexus dev --entrypoint` or `nexus build --entrypoint`.
    */
   entrypointPath?: string
+  projectRoot?: string
 }
 ```
 


### PR DESCRIPTION
Using `createTestContext` in a monorepo setting leads to the `Layout.create` function detecting the top level package.json and error out because that one doesn't have it's own name. However, by exposing the `projectRoot` option already accepted by `Layout.create`, we can circumvent this by resolving the path ahead of time, i.e.:
```ts
Object.assign(ctx, await originalCreateTestContext({ projectRoot: path.join(__dirname, '../..') }))
```

#### TODO

- [ ] docs
  - [x] jsdoc
  - [x] website api
  - [ ] website guides
  - [ ] website tutorial
- [ ] tests
