### PR TITLE
website(docs): fix typo

### DIFF
--- a/website/content/020-guides/110-configuration-management.mdx
+++ b/website/content/020-guides/110-configuration-management.mdx
@@ -21,7 +21,7 @@ Nexus takes a centralized approach to settings. All components in Nexus have the
 ```ts
 import { settings } from 'nexus'
 
-sttings.change({
+settings.change({
   server: {
     playground: false,
   },


### PR DESCRIPTION
Just a small typo fix

#### TODO

- [x] docs
  - [x] website guides
