### PR TITLE
fix(serverless): Fixes boolean checks for cors

### DIFF
--- a/src/runtime/server/apollo-server/serverless.ts
+++ b/src/runtime/server/apollo-server/serverless.ts
@@ -80,7 +80,6 @@ export class ApolloServerless extends ApolloServerBase {
 
   private isPlaygroundRequest(req: IncomingMessage) {
     const playgroundEnabled = Boolean(this.playgroundOptions) && req.method === 'GET'
-    const playgroundEnabled = this.playgroundOptions.enabled && req.method === 'GET'
     const acceptTypes = accepts(req).types() as string[]
     const prefersHTML =
       acceptTypes.find((x: string) => x === 'text/html') === 'text/html'

--- a/src/runtime/server/apollo-server/serverless.ts
+++ b/src/runtime/server/apollo-server/serverless.ts
@@ -80,6 +80,7 @@ export class ApolloServerless extends ApolloServerBase {
 
   private isPlaygroundRequest(req: IncomingMessage) {
     const playgroundEnabled = Boolean(this.playgroundOptions) && req.method === 'GET'
+    const playgroundEnabled = this.playgroundOptions.enabled && req.method === 'GET'
     const acceptTypes = accepts(req).types() as string[]
     const prefersHTML =
       acceptTypes.find((x: string) => x === 'text/html') === 'text/html'

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -81,7 +81,7 @@ export function create(appState: AppState) {
               {
                 path: settings.data.path,
                 introspection: settings.data.graphql.introspection,
-                playground: settings.data.playground.enabled ? settings.data.playground.settings : false,
+                playground: settings.data.playground,
                 errorFormatterFn: errorFormatter,
               }
             )

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -71,7 +71,7 @@ export function create(appState: AppState) {
       get graphql() {
         return (
           assembledGuard(appState, 'app.server.handlers.graphql', () => {
-            if (Boolean(settings.data.cors)) {
+            if (settings.data.cors.enabled) {
               log.warn('CORS does not work for serverless handlers. Settings will be ignored.')
             }
 
@@ -81,7 +81,12 @@ export function create(appState: AppState) {
               {
                 path: settings.data.path,
                 introspection: settings.data.graphql.introspection,
-                playground: settings.data.playground,
+                playground: settings.data.playground.enabled
+                  ? {
+                      endpoint: settings.data.path,
+                      settings: settings.data.playground.settings,
+                    }
+                  : false,
                 errorFormatterFn: errorFormatter,
               }
             )

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -81,12 +81,7 @@ export function create(appState: AppState) {
               {
                 path: settings.data.path,
                 introspection: settings.data.graphql.introspection,
-                playground: settings.data.playground.enabled
-                  ? {
-                      endpoint: settings.data.path,
-                      settings: settings.data.playground.settings,
-                    }
-                  : false,
+                playground: settings.data.playground.enabled ? settings.data.playground.settings : false
                 errorFormatterFn: errorFormatter,
               }
             )

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -81,7 +81,7 @@ export function create(appState: AppState) {
               {
                 path: settings.data.path,
                 introspection: settings.data.graphql.introspection,
-                playground: settings.data.playground,
+                playground: settings.data.playground.enabled ? settings.data.playground : false,
                 errorFormatterFn: errorFormatter,
               }
             )

--- a/src/runtime/server/server.ts
+++ b/src/runtime/server/server.ts
@@ -81,7 +81,7 @@ export function create(appState: AppState) {
               {
                 path: settings.data.path,
                 introspection: settings.data.graphql.introspection,
-                playground: settings.data.playground.enabled ? settings.data.playground.settings : false
+                playground: settings.data.playground.enabled ? settings.data.playground.settings : false,
                 errorFormatterFn: errorFormatter,
               }
             )


### PR DESCRIPTION
Updates playground and CORS settings equally as server-mode.
Prevents "▲ nexus:server CORS does not work for serverless handlers. Settings will be ignored." from showing when CORS isn't enabled by user.