### PR TITLE
chore(docs): minor typos in tutorial

### DIFF
--- a/website/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/website/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -166,7 +166,7 @@ Mutation {
 
 ## Model the domain: Part 2
 
-Before we wrap this chapter let's flush out our schema a bit more. We'll add a `publish` mutation to transform a draft into an actual published post, then we'll let API clients read the the published posts.
+Before we wrap this chapter let's flesh out our schema a bit more. We'll add a `publish` mutation to transform a draft into an actual published post, then we'll let API clients read the published posts.
 
 ```ts
 // api/graphql/Post.ts


### PR DESCRIPTION
closes #...

#### TODO

- [x] docs
  - [ ] jsdoc
  - [ ] website api
  - [ ] website guides
  - [x] website tutorial
- [ ] tests
