### PR TITLE
docs: correcting link to nexus-plugin-prisma

### DIFF
--- a/website/content/020-guides/10-writing-plugins.mdx
+++ b/website/content/020-guides/10-writing-plugins.mdx
@@ -225,4 +225,4 @@ export const plugin: RuntimePlugin<Settings, 'required'> = settings => project =
 
 - The most sophisticated real-world Nexus plugin is `nexus-plugin-prisma`.
 - It currently drives many of the requirements of the plugin system where we want nexus-prisma users to feel prisma is as seamless a component as any core one.
-- If you like learning by reading code, check it out here: [graphql-nexus/plugin-prisma](https://github.com/graphql-nexus/plugin-prisma).
+- If you like learning by reading code, check it out here: [graphql-nexus/nexus-plugin-prisma](https://github.com/graphql-nexus/nexus-plugin-prisma).


### PR DESCRIPTION
Found documentation issue, no GitHub issue logged.
