### PR TITLE
Broken example link fix

### DIFF
--- a/docs/content/010-getting-started/05-examples.mdx
+++ b/docs/content/010-getting-started/05-examples.mdx
@@ -4,4 +4,4 @@ title: Examples
 
 ## Examples
 
-You can find runnable examples of Nexus apps in the [repo](https://nxs.li/learn/examples).
+You can find runnable examples of Nexus apps in the [repo](https://github.com/graphql-nexus/nexus/tree/main/examples).


### PR DESCRIPTION
Fixes broken link to examples on https://nexusjs.org/docs/getting-started/examples