### PR TITLE
chore(docs): fix examples for abstract types to work with Typescript

### DIFF
--- a/docs/content/014-guides/025-abstract-types.mdx
+++ b/docs/content/014-guides/025-abstract-types.mdx
@@ -149,7 +149,8 @@ The Centralized strategy allows you to discriminate your union member types in a
 const SearchResult = unionType({
   name: 'SearchResult',
   resolveType(data) {
-    const __typename = data.album ? 'Song' : data.rating ? 'Movie' : data.width ? 'Photo' : null
+    const __typename =
+      'album' in data ? 'Song' : 'rating' in data ? 'Movie' : 'width' in data ? 'Photo' : null
 
     if (!__typename) {
       throw new Error(`Could not resolve the type of data passed to union type "SearchResult"`)
@@ -188,13 +189,8 @@ const Query = queryType({
       },
       resolve(root, args, ctx) {
         return ctx.db.search(args.pattern).map((result) => {
-          const __typename = result.album
-            ? 'Song'
-            : result.rating
-            ? 'Movie'
-            : result.width
-            ? 'Photo'
-            : null
+          const __typename =
+            'album' in data ? 'Song' : 'rating' in data ? 'Movie' : 'width' in data ? 'Photo' : null
 
           if (!__typename) {
             throw new Error(


### PR DESCRIPTION
Fix docs for abstract types to work with Typescript. With unions, it's not possible to use properties that are not intersections between these types. We can use `in` operator to have it working with Typescript.