### PR TITLE
feat: Add custom name options to Relay Connection plugin

### DIFF
--- a/docs/content/030-plugins/01-connection.mdx
+++ b/docs/content/030-plugins/01-connection.mdx
@@ -249,3 +249,33 @@ const schema = makeSchema({
   ],
 })
 ```
+
+## Custom names for Connection / Edge types
+
+You can provide a function to generate a custom name for connection and edge types. The function will receive the field and parent type names.
+
+### Globally
+
+```ts
+connectionPlugin({
+  getConnectionName(fieldName, parentTypeName) {
+    return `${parentTypeName}${upperFirst(fieldName)}Connection`
+  },
+  getEdgeName(fieldName, parentTypeName) {
+    return `${parentTypeName}${upperFirst(fieldName)}Edge`
+  },
+})
+```
+
+### One-off / per-field
+
+```ts
+t.connectionField('users', {
+  getConnectionName(fieldName, parentTypeName) {
+    return `${parentTypeName}${upperFirst(fieldName)}Connection`
+  },
+  getEdgeName(fieldName, parentTypeName) {
+    return `${parentTypeName}${upperFirst(fieldName)}Edge`
+  },
+})
+```

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -128,6 +128,10 @@ export interface ConnectionPluginConfig {
       requireResolver?: boolean
     }
   >
+  /** Allows specifying a custom name for connection types. */
+  getConnectionName?(filedName: string, parentTypeName: string): string
+  /** Allows specifying a custom name for edge types. */
+  getEdgeName?(filedName: string, parentTypeName: string): string
   /** Prefix for the Connection / Edge type */
   typePrefix?: string
   /**
@@ -241,6 +245,10 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
   extendEdge?: (
     def: ObjectDefinitionBlock<FieldTypeName<FieldTypeName<TypeName, FieldName>, 'edges'>>
   ) => void
+  /** Allows specifying a custom name for connection types. */
+  getConnectionName?(filedName: string, parentTypeName: string): string
+  /** Allows specifying a custom name for edge types. */
+  getEdgeName?(filedName: string, parentTypeName: string): string
   /** Configures the default "nonNullDefaults" for connection type generated for this connection */
   nonNullDefaults?: NonNullConfig
   /**
@@ -989,7 +997,11 @@ const getTypeNames = (
   // If we have changed the config specific to this field, on either the connection,
   // edge, or page info, then we need a custom type for the connection & edge.
   let connectionName: string
-  if (isConnectionFieldExtended(fieldConfig)) {
+  if (fieldConfig.getConnectionName) {
+    connectionName = fieldConfig.getConnectionName(fieldName, parentTypeName)
+  } else if (pluginConfig.getConnectionName) {
+    connectionName = pluginConfig.getConnectionName(fieldName, parentTypeName)
+  } else if (isConnectionFieldExtended(fieldConfig)) {
     connectionName = `${parentTypeName}${upperFirst(fieldName)}_Connection`
   } else {
     connectionName = `${pluginConfig.typePrefix || ''}${targetTypeName}Connection`
@@ -997,7 +1009,11 @@ const getTypeNames = (
 
   // If we have modified the "edge" at all, then we need
   let edgeName
-  if (isEdgeFieldExtended(fieldConfig)) {
+  if (fieldConfig.getEdgeName) {
+    edgeName = fieldConfig.getEdgeName(fieldName, parentTypeName)
+  } else if (pluginConfig.getEdgeName) {
+    edgeName = pluginConfig.getEdgeName(fieldName, parentTypeName)
+  } else if (isEdgeFieldExtended(fieldConfig)) {
     edgeName = `${parentTypeName}${upperFirst(fieldName)}_Edge`
   } else {
     edgeName = `${pluginConfig.typePrefix || ''}${targetTypeName}Edge`

--- a/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
@@ -442,6 +442,10 @@ type UserEdge {
 "
 `;
 
+exports[`field level configuration can configure connection names per-instance 1`] = `"QueryUsersTestFieldConnection"`;
+
+exports[`field level configuration can configure edge names per-instance 1`] = `"QueryUsersTestFieldEdge"`;
+
 exports[`field level configuration can configure the connection per-instance 1`] = `
 "type QueryUsers_Connection {
   \\"\\"\\"
@@ -725,6 +729,10 @@ exports[`global plugin configuration can configure additional fields for the edg
   createdAt: String
 }"
 `;
+
+exports[`global plugin configuration can configure connection names globally 1`] = `"QueryUsersTestGlobalConnection"`;
+
+exports[`global plugin configuration can configure edge names globally 1`] = `"QueryUsersTestGlobalEdge"`;
 
 exports[`global plugin configuration can define additional args for all connections 1`] = `
 "type Query {

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -19,6 +19,10 @@ for (let i = 0; i < 10; i++) {
   userNodes.push({ id: `User:${i + 1}`, name: `Test ${i + 1}` })
 }
 
+const upperFirst = (fieldName: string) => {
+  return fieldName.slice(0, 1).toUpperCase().concat(fieldName.slice(1))
+}
+
 const User = objectType({
   name: 'User',
   definition(t) {
@@ -666,6 +670,28 @@ describe('global plugin configuration', () => {
     expect(printType(schema.getType('UserConnection')!)).toMatchSnapshot()
   })
 
+  it('can configure connection names globally', () => {
+    const suffix = 'TestGlobalConnection'
+    const schema = makeTestSchema({
+      getConnectionName(fieldName, parentTypeName) {
+        return `${parentTypeName}${upperFirst(fieldName)}${suffix}`
+      },
+    })
+
+    expect(schema.getType(`QueryUsers${suffix}`)).toMatchSnapshot()
+  })
+
+  it('can configure edge names globally', () => {
+    const suffix = 'TestGlobalEdge'
+    const schema = makeTestSchema({
+      getEdgeName(fieldName, parentTypeName) {
+        return `${parentTypeName}${upperFirst(fieldName)}${suffix}`
+      },
+    })
+
+    expect(schema.getType(`QueryUsers${suffix}`)).toMatchSnapshot()
+  })
+
   it('logs error if the extendConnection resolver is not specified', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation()
     makeTestSchema({
@@ -769,6 +795,34 @@ describe('field level configuration', () => {
     )
     expect(printType(schema.getType('QueryUsers_Connection')!)).toMatchSnapshot()
     expect(printType(schema.getType('QueryUsers_Edge')!)).toMatchSnapshot()
+  })
+
+  it('can configure connection names per-instance', () => {
+    const suffix = 'TestFieldConnection'
+    const schema = makeTestSchema(
+      {},
+      {
+        getConnectionName(fieldName, parentTypeName) {
+          return `${parentTypeName}${upperFirst(fieldName)}${suffix}`
+        },
+      }
+    )
+
+    expect(schema.getType(`QueryUsers${suffix}`)).toMatchSnapshot()
+  })
+
+  it('can configure edge names per-instance', () => {
+    const suffix = 'TestFieldEdge'
+    const schema = makeTestSchema(
+      {},
+      {
+        getEdgeName(fieldName, parentTypeName) {
+          return `${parentTypeName}${upperFirst(fieldName)}${suffix}`
+        },
+      }
+    )
+
+    expect(schema.getType(`QueryUsers${suffix}`)).toMatchSnapshot()
   })
 
   it('can modify the behavior of cursorFromNode ', () => {})


### PR DESCRIPTION
Adds a getConnectionName and getEdgeName option to both the global
plugin config as well as the field config for the Relay Connection
plugin. This gives the user the ability to control the names of the
generated connection and edge types in the schema.

Closes #697

Prettier seems to have re-formatted some comments. I can remove these changes or put them in a separate commit if needed. Also, please let me know if the option descriptions and the tests are acceptable.

cc: @tgriesser 