### PR TITLE
chore(docs): Fix missing export

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -131,6 +131,7 @@ export const schema = makeSchema({
 +  contextType: {                                    // 1
 +    module: join(__dirname, "./context.ts"),        // 2
 +    alias: "ContextModule",                         // 3
++    export: "Context",                              // 4
 +  },
 })
 ```


### PR DESCRIPTION
Address the error "Property 'export' is missing in type '{ module: string; alias: string; }' but required in type 'TypingImport'.ts(2741)"