### PR TITLE
Add missing import of db client to code diff in testing tutorial

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
@@ -44,6 +44,7 @@ import { GraphQLClient } from "graphql-request";
 +import { nanoid } from "nanoid";
 +import { join } from "path";
 +import { Client } from "pg";
++import { db } from "../api/db";
 import { server } from "../api/server";
 
 type TestContext = {


### PR DESCRIPTION
Add missing import of db client to code diff in testing tutorial

The `Code` tab has this import but the diff tab is missing it and doesn't make sense without it.