### PR TITLE
chore(docs): fix docs overview link 404ing to repo examples

### DIFF
--- a/docs/content/030-plugins/050-prisma/010-overview.mdx
+++ b/docs/content/030-plugins/050-prisma/010-overview.mdx
@@ -21,7 +21,7 @@ npm add -D @prisma/cli
 
 > **Note**: If you're looking for CRUD capabilities, you must enable the `experimentalCRUD` option.
 
-You can find runnable examples in the [repo examples folder](https://github.com/graphql-nexus/nexus-schema-plugin-prisma/tree/master/examples/schema).
+You can find runnable examples in the [repo examples folder](https://github.com/graphql-nexus/nexus-plugin-prisma/tree/main/examples).
 
 **Example**
 


### PR DESCRIPTION
Current one 404s! I _think_ this is where it is meant to point..please do check.