### PR TITLE
fix(docs): update 07-chapter-6-testing-with-prisma.mdx

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
@@ -113,7 +113,7 @@ function graphqlTestContext() {
 +       process.env.DATABASE_URL = databaseUrl;
 +
 +       // Run the migrations to ensure our schema has the required structure
-+       execSync(`${prismaBinary} migrate deploy --preview-feature`, {
++       execSync(`${prismaBinary} migrate dev --preview-feature`, {
 +         env: {
 +           ...process.env,
 +           DATABASE_URL: databaseUrl,


### PR DESCRIPTION
current implementation `prisma migrate up --create-db --experimental` throws the following error:

```
Command failed: /Users/canrozanes/Projects/ikiler-file-manager/node_modules/.bin/prisma migrate up --create-db --experimental
    Error: The current command "up" doesn't exist in the new version of Prisma Migrate.
    Read more about how to upgrade: https://pris.ly/d/migrate-upgrade
```

Changing the command to `prisma migrate dev --preview-feature` fixes the problem and runs the tests and passes them.