### PR TITLE
chore(docs): remove outdated prisma plugin config docs

### DIFF
--- a/docs/content/030-plugins/050-prisma/010-overview.mdx
+++ b/docs/content/030-plugins/050-prisma/010-overview.mdx
@@ -427,27 +427,6 @@ input UserWhereUniqueInput {
 
 </div>
 
-## Plugin settings
-
-You can _optionally_ configure the plugin. Refer to the jsDoc for details. Here is an example:
-
-```ts
-import { nexusPrisma } from 'nexus-plugin-prisma'
-import { makeSchema } from 'nexus'
-import { PrismaClient } from 'nexus-plugin-prisma/client'
-
-const schema = makeSchema({
-  plugins: [
-    nexusPrisma({
-      experimentalCRUD: true,
-      client: {
-        instance: new PrismaClient()
-      }
-    })
-  ],
-})
-```
-
 ## Recipes
 
 ### Projecting Prisma model fields


### PR DESCRIPTION
@jasonkuhrt Remove the [plugin settings section](https://nexusjs.org/docs/plugins/prisma/overview#plugin-settings) entirely. It contains more deprecated code like using `client` property which is now replaced by `prismaClient` of type `PrismaClientFetcher`

In addition, It's already covered in [configuration section](https://nexusjs.org/docs/plugins/prisma/overview#configuration) above.