### PR TITLE
docs: fix code example

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/03-chapter-2-writing-your-first-schema.mdx
+++ b/docs/content/010-getting-started/03-tutorial/03-chapter-2-writing-your-first-schema.mdx
@@ -20,7 +20,7 @@ Before we get going we need a moment to introduce an important part of the Nexus
 
 This partly explains why Nexus has a declarative API. It needs a way to run your app reliably at build time. Declarative APIs give Nexus a higher degree of control to do this. Declarative APIs also encode enough semantic value for Nexus to do the things it needs to.
 
-It also explains the need for the `--transpile-only` flag passed to `ts-node-dev`. If you don't know what it is about, **it basically tells TypeScript not to typecheck your app**. Since `nexus` needs to be run in order to generate TypeScript types, we need to ensure that `nexus` won't ever be prevented from generating these types because of.. a type error.
+It also explains the need for the `--transpile-only` flag passed to `ts-node-dev`. If you don't know what it is about, **it basically tells TypeScript not to typecheck your app**. Since `nexus` needs to be run in order to generate TypeScript types, we need to ensure that `nexus` won't ever be prevented from generating these types because of a type error.
 
 You might be (rightfully) wondering: "Wait, how am I supposed to benefit from Nexus' type-safety if I disable it in `ts-node-dev`... ?". For now, the answer to that is to use your IDE's type-checker. If your IDE/terminal doesn't have one, then manually run an additional `tsc` process.
 

--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -130,7 +130,7 @@ export const schema = makeSchema({
   },
 +  contextType: {                                    // 1
 +    module: join(__dirname, "./context.ts"),        // 2
-+    export: "Context",                              // 3
++    alias: "ContextModule",                         // 3
 +  },
 })
 ```

--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -130,8 +130,7 @@ export const schema = makeSchema({
   },
 +  contextType: {                                    // 1
 +    module: join(__dirname, "./context.ts"),        // 2
-+    alias: "ContextModule",                         // 3
-+    export: "Context",                              // 4
++    export: "Context",                              // 3
 +  },
 })
 ```

--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -278,7 +278,7 @@ Let's revise our implementation with GraphQL arguments.
 
 
 ```ts
-import { objectType, extendType, stringArg } from 'nexus'
+import { objectType, extendType } from 'nexus'
 +import { objectType, extendType, stringArg, nonNull } from 'nexus'
 
 export const PostMutation = extendType({

--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -271,7 +271,7 @@ We need to get the client's input data to complete our resolver. This brings us 
 
 Let's revise our implementation with GraphQL arguments.
 
-<TabbedContent tabs={['Diff', 'Code']}>
+<TabbedContent tabs={['Diff', 'Code', 'SDL']}>
 
 <tab>
 
@@ -340,7 +340,7 @@ export const PostMutation = extendType({
 
 </tab>
 
-</TabbedContent>
+<tab>
 
 ```ts
 Mutation {
@@ -348,6 +348,10 @@ Mutation {
 +  createDraft(title: String!, body: String!): Post!
 }
 ```
+
+</tab>
+
+</TabbedContent>
 
 1. Add an `args` property to the field definition to define its args. Keys are arg names and values are type specifications.
 2. Use the Nexus helpers for defining an arg type. There is one such helper for every GraphQL scalar such as `intArg` and `booleanArg`. If you want to reference a type like some InputObject then use `arg({ type: "..." })`. You can use the helpers `nonNull` and `nullable` to adjust the nullability type of the arg. You can use the functional helper `list` to turn the arg into a list type too.


### PR DESCRIPTION
1. Code and diff tabs code don't match
2. This is the first appearance of `stringArg`, it's never used before.
3. Display SDL code in a tab (same manner as the existing code below)