### PR TITLE
feat: add plugin support for inputObjectType

### DIFF
--- a/src/definitions/inputObjectType.ts
+++ b/src/definitions/inputObjectType.ts
@@ -3,7 +3,7 @@ import { arg, NexusArgDef, NexusAsArgConfig } from './args'
 import { InputDefinitionBlock } from './definitionBlocks'
 import { NexusTypes, NonNullConfig, withNexusSymbol } from './_types'
 
-export interface NexusInputObjectTypeConfig<TypeName extends string> {
+export type NexusInputObjectTypeConfig<TypeName extends string> = {
   /** Name of the input object type */
   name: TypeName
   /** Definition block for the input type */
@@ -21,7 +21,7 @@ export interface NexusInputObjectTypeConfig<TypeName extends string> {
    * @see https://github.com/graphql/graphql-js/issues/1527
    */
   extensions?: GraphQLInputObjectTypeConfig['extensions']
-}
+} & NexusGenPluginInputTypeConfig<TypeName>
 
 export class NexusInputObjectTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusInputObjectTypeConfig<any>) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,6 +54,8 @@ export interface PluginConfig {
   inputFieldDefTypes?: StringLike | StringLike[]
   /** Any type definitions we want to add to the type definition option */
   objectTypeDefTypes?: StringLike | StringLike[]
+  /** Any type definitions we want to add to the input type definition option */
+  inputObjectTypeDefTypes?: StringLike | StringLike[]
   /** Any type definitions we want to add to the arg definition option */
   argTypeDefTypes?: StringLike | StringLike[]
   /**
@@ -230,6 +232,7 @@ function validatePluginConfig(pluginConfig: PluginConfig): void {
     'fieldDefTypes',
     'inputFieldDefTypes',
     'objectTypeDefTypes',
+    'inputObjectTypeDefTypes',
     'argTypeDefTypes',
     ...optionalPropFns,
   ]

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -841,6 +841,9 @@ export class TypegenPrinter {
     const pluginArgExt: string[] = [`  interface NexusGenPluginArgConfig {`]
     const pluginSchemaExt: string[] = [`  interface NexusGenPluginSchemaConfig {`]
     const pluginTypeExt: string[] = [`  interface NexusGenPluginTypeConfig<TypeName extends string> {`]
+    const pluginInputTypeExt: string[] = [
+      `  interface NexusGenPluginInputTypeConfig<TypeName extends string> {`,
+    ]
     const printInlineDefs: string[] = []
     const plugins = this.schema.extensions.nexus.config.plugins || []
     plugins.forEach((plugin) => {
@@ -853,6 +856,9 @@ export class TypegenPrinter {
       if (plugin.config.objectTypeDefTypes) {
         pluginTypeExt.push(padLeft(this.printType(plugin.config.objectTypeDefTypes), '    '))
       }
+      if (plugin.config.inputObjectTypeDefTypes) {
+        pluginInputTypeExt.push(padLeft(this.printType(plugin.config.inputObjectTypeDefTypes), '    '))
+      }
       if (plugin.config.argTypeDefTypes) {
         pluginArgExt.push(padLeft(this.printType(plugin.config.argTypeDefTypes), '    '))
       }
@@ -863,6 +869,7 @@ export class TypegenPrinter {
         'declare global {',
         [
           pluginTypeExt.concat('  }').join('\n'),
+          pluginInputTypeExt.concat('  }').join('\n'),
           pluginFieldExt.concat('  }').join('\n'),
           pluginInputFieldExt.concat('  }').join('\n'),
           pluginSchemaExt.concat('  }').join('\n'),

--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -9,6 +9,7 @@ declare global {
   interface NexusGenCustomOutputProperties<TypeName extends string> {}
   interface NexusGenPluginSchemaConfig {}
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginArgConfig {}

--- a/tests/__snapshots__/backingTypes.spec.ts.snap
+++ b/tests/__snapshots__/backingTypes.spec.ts.snap
@@ -132,6 +132,8 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
   }
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
+  }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
   }
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {

--- a/tests/__snapshots__/typegenPrinter.spec.ts.snap
+++ b/tests/__snapshots__/typegenPrinter.spec.ts.snap
@@ -370,6 +370,8 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
   }
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
+  }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
   }
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {

--- a/tests/integrations/abstractTypes/allStrategiesOptionalWhenTypeNameEnabled/__typegen.ts
+++ b/tests/integrations/abstractTypes/allStrategiesOptionalWhenTypeNameEnabled/__typegen.ts
@@ -135,6 +135,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/abstractTypes/isTypeOfsImplemented/__typegen.ts
+++ b/tests/integrations/abstractTypes/isTypeOfsImplemented/__typegen.ts
@@ -133,6 +133,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/abstractTypes/missingIsTypeOf/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingIsTypeOf/__typegen.ts
@@ -133,6 +133,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/abstractTypes/missingResolveType/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingResolveType/__typegen.ts
@@ -133,6 +133,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/abstractTypes/missingResolveTypeOrIsTypeOf/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingResolveTypeOrIsTypeOf/__typegen.ts
@@ -123,6 +123,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/abstractTypes/missingTypenameDiscriminant/__typegen.ts
+++ b/tests/integrations/abstractTypes/missingTypenameDiscriminant/__typegen.ts
@@ -135,6 +135,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/abstractTypes/resolveTypeImplemented/__typegen.ts
+++ b/tests/integrations/abstractTypes/resolveTypeImplemented/__typegen.ts
@@ -133,6 +133,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/declarativeWrappingPlugin/__typegen.ts
+++ b/tests/integrations/declarativeWrappingPlugin/__typegen.ts
@@ -136,6 +136,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
     /**
      * Whether the type can be null

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -354,6 +354,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/integrations/unionTooComplexToRepresent/__typegen.ts
+++ b/tests/integrations/unionTooComplexToRepresent/__typegen.ts
@@ -4713,6 +4713,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}

--- a/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/fieldAuthorizePlugin.spec.ts.snap
@@ -161,6 +161,8 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
   }
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
+  }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
     /**
      * Authorization for an individual field. Returning \\"true\\"

--- a/tests/plugins/__snapshots__/queryComplexityPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/queryComplexityPlugin.spec.ts.snap
@@ -119,6 +119,8 @@ export interface NexusGenTypes {
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {
   }
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {
+  }
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {
     /**
      * The complexity for an individual field. Return a number

--- a/tests/typegen/types.gen.ts
+++ b/tests/typegen/types.gen.ts
@@ -225,6 +225,7 @@ export interface NexusGenTypes {
 
 declare global {
   interface NexusGenPluginTypeConfig<TypeName extends string> {}
+  interface NexusGenPluginInputTypeConfig<TypeName extends string> {}
   interface NexusGenPluginFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginInputFieldConfig<TypeName extends string, FieldName extends string> {}
   interface NexusGenPluginSchemaConfig {}


### PR DESCRIPTION
### Motivation

There's currently no way of extending `inputObjectType` through a plugin like we can do with `objectType`. I'm writing a validation plugin and [I need to "hook in" to the type for input objects](https://github.com/filipstefansson/nexus-validate/pull/9).

### Implementation

I copied the implementation for `NexusGenPluginTypeConfig` and renamed it to `NexusGenPluginInputTypeConfig`.

###  Example

```ts
// my-plugin.ts
const inputObjectdDefTypes = printedGenTyping({
  name: 'pluginName',
  type: 'string',
  ...
});

const myPlugin = () => {
  return plugin({
    ...
    inputObjectTypeDefTypes: inputObjectdDefTypes,
  });
}
```

```ts
// schema.ts
const MyInput = inputObjectType({
  ...
  pluginName: 'hello world',
});
```

Let me know if this is relevant and if my solution works!