### PR TITLE
chore(docs): asNexusMethod import is missing

### DIFF
--- a/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
+++ b/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
@@ -392,7 +392,7 @@ You need to explicitly setup all custom scalars yourself. To match what Nexus Fr
 2. Setup the `Json` and `DateTime` scalars
 
    ```tsx
-   import { makeSchema } from 'nexus'
+   import { makeSchema, asNexusMethod } from 'nexus'
    import { DateTimeResolver, JSONObjectResolver } from 'graphql-scalars'
 
    const jsonScalar = asNexusMethod(JSONObjectResolver, 'json')


### PR DESCRIPTION
asNexusMethod should also be imported in order to be used with graphql-scalars