### PR TITLE
chore(docs): Correct an object's value in the tutorial

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/04-chapter-3-adding-mutations-to-your-api.mdx
@@ -130,7 +130,7 @@ export const schema = makeSchema({
   },
 +  contextType: {                                    // 1
 +    module: join(__dirname, "./context.ts"),        // 2
-+    export: "ContextModule",                        // 3
++    export: "Context",                              // 3
 +  },
 })
 ```


### PR DESCRIPTION
In the ContextType Object, the value of `export` should be `Context` instead of `ContextModule` (see Line 133)
On line 62, the name of the exported interface is `Context`.

I have noticed that autocompletion of Prisma doesn't work because of the misspelling :)

When I checked the repository of the tutorial the value of `export` was correct.
https://github.com/graphql-nexus/tutorial/blob/e7a1988eded47a818398d14d823e45423ddeb3dd/api/schema.ts#L12