### PR TITLE
feat: connectionPlugin internal modifications

### DIFF
--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -890,13 +890,13 @@ function provideArgs(block: ObjectDefinitionBlock<any>, fn: () => void) {
 
 function iterateNodes(nodes: any[], args: PaginationArgs, cb: (node: any, i: number) => void) {
   // If we want the first N of an array of nodes, it's pretty straightforward.
-  if (args.first) {
+  if (typeof args.first === 'number') {
     for (let i = 0; i < args.first; i++) {
       if (i < nodes.length) {
         cb(nodes[i], i)
       }
     }
-  } else if (args.last) {
+  } else if (typeof args.last === 'number') {
     for (let i = 0; i < args.last; i++) {
       const idx = nodes.length - args.last + i
       if (idx >= 0) {

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -231,7 +231,7 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
    * with `first` or `last`, respectively.
    */
   validateArgs?: (
-    args: Record<string, any>,
+    args: ArgsValue<TypeName, FieldName>,
     info: GraphQLResolveInfo,
     root: SourceValue<TypeName>,
     ctx: GetGen<'context'>

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -72,6 +72,8 @@ const UsersFieldBody = `
   }
 `
 
+const UsersAll = parse(`query UsersAll { users { ${UsersFieldBody} } }`)
+
 const UsersLast = parse(`query UsersFieldLast($last: Int!) { users(last: $last) { ${UsersFieldBody} } }`)
 const UsersLastBefore = parse(
   `query UsersFieldLastBefore($last: Int!, $before: String!) { users(last: $last, before: $before) { ${UsersFieldBody} } }`
@@ -651,6 +653,22 @@ describe('global plugin configuration', () => {
       strictArgs: false,
     })
     expect(printType(schema.getQueryType()!)).toMatchSnapshot()
+  })
+
+  it('iterates all nodes if neither first/last are matched', async () => {
+    const schema = makeTestSchema({
+      disableBackwardPagination: true,
+      strictArgs: false,
+      pageInfoFromNodes() {
+        return { hasNextPage: false, hasPreviousPage: false }
+      },
+      validateArgs() {},
+    })
+    const result = await executeOk({
+      schema,
+      document: UsersAll,
+    })
+    expect(result.data?.users?.edges.length).toEqual(10)
   })
 
   it('can configure additional fields for the connection globally', () => {


### PR DESCRIPTION
- Adds `(root, ctx)` to `validateArgs`
- Iterate all nodes if neither `first` or `last` are provided, e.g. with custom `validateArgs`
- Export additional internal fns on `connectionPlugin`