### PR TITLE
fix: pass down source into extended connection fields

### DIFF
--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -11,6 +11,7 @@ import {
   inputObjectType,
   interfaceType,
   mutationType,
+  nonNull,
   objectType,
   queryType,
   scalarType,
@@ -136,6 +137,13 @@ export const User = objectType({
       type: Post,
       nodes() {
         return mockData.posts
+      },
+      totalCount(root) {
+        if (!root.firstName) {
+          // root.firstName should be the source value here
+          throw new Error()
+        }
+        return 0
       },
       edgeFields: {
         delta(root, args, ctx) {
@@ -295,6 +303,11 @@ export const plugins = [
         args: {
           format: 'String',
         },
+      },
+    },
+    extendConnection: {
+      totalCount: {
+        type: nonNull('Int'),
       },
     },
   }),

--- a/tests/integrations/kitchenSink/__schema.graphql
+++ b/tests/integrations/kitchenSink/__schema.graphql
@@ -62,6 +62,7 @@ type PostConnection {
   https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
   """
   pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type PostEdge {

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -28,6 +28,7 @@ declare global {
     connectionField<FieldName extends string>(
       fieldName: FieldName,
       config: connectionPluginCore.ConnectionFieldConfig<TypeName, FieldName> & {
+        totalCount: connectionPluginCore.ConnectionFieldResolver<TypeName, FieldName, 'totalCount'>
         edgeFields: { delta: connectionPluginCore.EdgeFieldResolver<TypeName, FieldName, 'delta'> }
       }
     ): void
@@ -145,6 +146,7 @@ export interface NexusGenFieldTypes {
     // field return type
     edges: Array<NexusGenRootTypes['PostEdge'] | null> | null // [PostEdge]
     pageInfo: NexusGenRootTypes['PageInfo'] // PageInfo!
+    totalCount: number // Int!
   }
   PostEdge: {
     // field return type
@@ -213,6 +215,7 @@ export interface NexusGenFieldTypeNames {
     // field return type name
     edges: 'PostEdge'
     pageInfo: 'PageInfo'
+    totalCount: 'Int'
   }
   PostEdge: {
     // field return type name

--- a/tests/plugins/connectionPlugin.spec.ts
+++ b/tests/plugins/connectionPlugin.spec.ts
@@ -1250,4 +1250,60 @@ describe('connectionPlugin extensions', () => {
       })
     })
   })
+
+  describe('should receive the connection source field when extending', () => {
+    test('the connection type on the schema', async () => {
+      const schema = makeTestSchema(
+        {
+          extendConnection: {
+            count: {
+              type: 'Int',
+              args: {
+                round: 'Int',
+              },
+            },
+          },
+        },
+        {
+          // @ts-ignore
+          count(root, args, ctx) {
+            expect(root).toEqual({ someId: 123 })
+            return 100
+          },
+        }
+      )
+      await executeOk({
+        schema,
+        document: CountFirst,
+        rootValue: { someId: 123 },
+        variableValues: { first: 1, ok: true },
+      })
+    })
+
+    test('the connection type on the field', async () => {
+      expect.assertions(2)
+      const schema = makeTestSchema(
+        {},
+        {
+          extendConnection(t) {
+            t.int('count', {
+              args: {
+                round: 'Int',
+              },
+              resolve(root, args, ctx) {
+                expect(root).toEqual({ someId: 123 })
+                return 100
+              },
+            })
+          },
+        }
+      )
+      await executeOk({
+        schema,
+        document: CountFirst,
+        rootValue: { someId: 123 },
+        variableValues: { first: 1, ok: true },
+      })
+    })
+  })
 })


### PR DESCRIPTION
The current functionality is useless as-is, because presumably you need to know the "source" value for an extended connection resolver in order to have the proper context to resolve it. Adds a fix, so the extended resolvers work similar to the `nodes` field and receive the source as the first value.

If anyone has issues with this, we can revert and make this opt-in, but this was the original intended behavior for extended connection fields, it just wasn't implemented correctly.