### PR TITLE
chore(docs): Updated tutorial docs (chapter 5 persisting-data-via-prisma) to fix cli install instructions

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -31,7 +31,7 @@ Prisma has great [docs](https://www.prisma.io/docs/understand-prisma/introductio
 
 Now that you know a bit about Prisma, let's get going! Do the following:
 
-- Install the Prisma CLI
+- Install the Prisma client and CLI
 - Use it in your `api/schema.ts` module
 - Create your Prisma Schema
 - Create a `.env` file to store your database credentials
@@ -40,6 +40,7 @@ Now that you know a bit about Prisma, let's get going! Do the following:
 like so:
 
 ```bash-symbol
+npm add @prisma/client
 npm add --save-dev prisma
 ```
 

--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -31,7 +31,7 @@ Prisma has great [docs](https://www.prisma.io/docs/understand-prisma/introductio
 
 Now that you know a bit about Prisma, let's get going! Do the following:
 
-- Install the Prisma Client & the Prisma CLI
+- Install the Prisma CLI
 - Use it in your `api/schema.ts` module
 - Create your Prisma Schema
 - Create a `.env` file to store your database credentials
@@ -40,7 +40,7 @@ Now that you know a bit about Prisma, let's get going! Do the following:
 like so:
 
 ```bash-symbol
-npm add @prisma/client && npm add --save-dev @prisma/cli
+npm add --save-dev prisma
 ```
 
 ```bash-symbol


### PR DESCRIPTION
The prisma/cli has been renamed prisma, although the tutorial works fine if you install the prisma/cli this wont be the case forever. best update the docs now to avoid future confusion