### PR TITLE
fix: make connectionPlugin compliant with Relay Connections spec

### DIFF
--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -489,7 +489,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                 objectType({
                   name: connectionName,
                   definition(t2) {
-                    t2.list.field('edges', {
+                    t2.nullable.list.nullable.field('edges', {
                       type: edgeName as any,
                       description: `https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types`,
                     })
@@ -529,7 +529,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                       type: cursorType ?? nonNull('String'),
                       description: 'https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor',
                     })
-                    t2.field('node', {
+                    t2.nonNull.field('node', {
                       type: targetType,
                       description: 'https://facebook.github.io/relay/graphql/connections.htm#sec-Node',
                     })

--- a/tests/integrations/kitchenSink/__schema.graphql
+++ b/tests/integrations/kitchenSink/__schema.graphql
@@ -75,7 +75,7 @@ type PostEdge {
   """
   https://facebook.github.io/relay/graphql/connections.htm#sec-Node
   """
-  node: Post
+  node: Post!
 }
 
 input PostSearchInput {

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -96,11 +96,13 @@ export interface NexusGenObjects {
     // root type
     edges?: Array<NexusGenRootTypes['PostEdge'] | null> | null // [PostEdge]
     pageInfo: NexusGenRootTypes['PageInfo'] // PageInfo!
+    totalCount: number // Int!
   }
   PostEdge: {
     // root type
     cursor: string // String!
-    node?: NexusGenRootTypes['Post'] | null // Post
+    delta?: string | null // String
+    node: NexusGenRootTypes['Post'] // Post!
   }
   Query: {}
   Subscription: {}
@@ -152,7 +154,7 @@ export interface NexusGenFieldTypes {
     // field return type
     cursor: string // String!
     delta: string | null // String
-    node: NexusGenRootTypes['Post'] | null // Post
+    node: NexusGenRootTypes['Post'] // Post!
   }
   Query: {
     // field return type

--- a/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
@@ -200,7 +200,7 @@ exports[`basic behavior should adhere to the Relay spec 2`] = `
   cursor: String!
 
   \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
-  node: User
+  node: User!
 }"
 `;
 
@@ -303,7 +303,7 @@ type QueryFieldLevel_Connection {
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
-  edges: [QueryFieldLevel_Edge!]!
+  edges: [QueryFieldLevel_Edge]
 
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
@@ -324,7 +324,7 @@ type QueryFieldLevel2_Connection {
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
-  edges: [QueryFieldLevel2_Edge!]!
+  edges: [QueryFieldLevel2_Edge]
 
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
@@ -350,7 +350,7 @@ type UserConnection {
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
-  edges: [UserEdge!]!
+  edges: [UserEdge]
 
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
@@ -424,7 +424,7 @@ type UserConnection {
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
-  edges: [UserEdge!]!
+  edges: [UserEdge]
 
   \\"\\"\\"
   https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
@@ -481,7 +481,7 @@ exports[`field level configuration can configure the edge per-instance 2`] = `
   cursor: String!
 
   \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
-  node: User
+  node: User!
   role: String
 }"
 `;
@@ -507,7 +507,7 @@ type AnalyticsUserEdge {
   cursor: String!
 
   \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
-  node: User
+  node: User!
 }
 
 \\"\\"\\"
@@ -586,7 +586,7 @@ type UserEdge {
   cursor: String!
 
   \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
-  node: User
+  node: User!
 }
 "
 `;
@@ -725,7 +725,7 @@ exports[`global plugin configuration can configure additional fields for the edg
   cursor: String!
 
   \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
-  node: User
+  node: User!
   createdAt: String
 }"
 `;


### PR DESCRIPTION
Fixes: #844 

The Relay Connections specification says:

> If ExampleConnection existed in the type system, it would be a connection, since its name ends in “Connection”. If this connection’s edge type was named ExampleEdge, then a server that correctly implements the above requirement would accept the following introspection query, and return the provided response:

```gql
{
  __type(name: "ExampleConnection") {
    fields {
      name
      type {
        name
        kind
        ofType {
          name
          kind
        }
      }
    }
  }
}
```

> returns

```json
{
  "data": {
    "__type": {
      "fields": [
        // May contain other items
        {
          "name": "pageInfo",
          "type": {
            "name": null,
            "kind": "NON_NULL",
            "ofType": {
              "name": "PageInfo",
              "kind": "OBJECT"
            }
          }
        },
        {
          "name": "edges",
          "type": {
            "name": null,
            "kind": "LIST",
            "ofType": {
              "name": "ExampleEdge",
              "kind": "OBJECT"
            }
          }
        }
      ]
    }
  }
}
```

https://relay.dev/graphql/connections.htm#sec-Connection-Types.Introspection

Furthermore, it also says:

> An “Edge Type” must contain a field called node. This field must return either a Scalar, Enum, Object, Interface, Union, or a Non‐Null wrapper around one of those types. Notably, this field cannot return a list.

https://relay.dev/graphql/connections.htm#sec-Node

The nullability of these fields can currently be controlled in a limited way through the `nonNullDefaults` configuration option.  I believe the specification can not be satisfied with the current limitations around configurability. This PR makes sure the connection plugin is compliant with the specification. If consumers need to use non-compliant connection types, they should implement their own plugin/types until the limitations around configurability are addressed.