### PR TITLE
chore(docs): fix broken link in 070-make-schema.mdx

### DIFF
--- a/docs/content/015-api/070-make-schema.mdx
+++ b/docs/content/015-api/070-make-schema.mdx
@@ -94,7 +94,7 @@ makeSchema({
 })
 ```
 
-The [Ghost Example](https://github.com/graphql-nexus/nexus/blob/develop/examples/ghost/src/ghost-schema.ts) is the best place to look for an example of how we're able to capture the types from existing runtime objects or definitions and merge them with our schema.
+The [Ghost Example](https://github.com/graphql-nexus/nexus/blob/main/examples/ghost/src/ghost-schema.ts) is the best place to look for an example of how we're able to capture the types from existing runtime objects or definitions and merge them with our schema.
 
 ## shouldExitAfterGenerateArtifacts
 


### PR DESCRIPTION
Looks like the previous link points to a branch `develop` that no longer exists.