### PR TITLE
chore(docs): Change --transpileOnly to --transpile-only from star-wars example

### DIFF
--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -2,7 +2,7 @@
   "name": "@graphql-nexus/example-swapi-example",
   "version": "0.0.0",
   "scripts": {
-    "start": "ts-node-dev --ignore-watch star-wars-typegen.ts --no-notify --transpileOnly --respawn ./src"
+    "start": "ts-node-dev --ignore-watch star-wars-typegen.ts --no-notify --respawn ./src"
   },
   "dependencies": {
     "apollo-server": "^2.18.1",

--- a/examples/star-wars/package.json
+++ b/examples/star-wars/package.json
@@ -2,7 +2,7 @@
   "name": "@graphql-nexus/example-swapi-example",
   "version": "0.0.0",
   "scripts": {
-    "start": "ts-node-dev --ignore-watch star-wars-typegen.ts --no-notify --respawn ./src"
+    "start": "ts-node-dev --ignore-watch star-wars-typegen.ts --no-notify --transpile-only --respawn ./src"
   },
   "dependencies": {
     "apollo-server": "^2.18.1",


### PR DESCRIPTION
ts-node-dev will not start the process if --transpileOnly is passed as it is deprecated.