### PR TITLE
chore(docs): Obsolete example of using a custom typing to GraphQL context value on makeSchema API

### DIFF
--- a/docs/content/015-api/070-make-schema.mdx
+++ b/docs/content/015-api/070-make-schema.mdx
@@ -79,17 +79,17 @@ makeSchema({
         typeMatch: name => new RegExp(`(?:interface|type|class)\\s+(${name}s?)\\W`, 'g'),
       },
     ],
-    // Typing for the GraphQL context
-    contextType: {
-      module: '@packages/data-context/src/DataContext.ts',
-      alias: 'ctx',
-    },
     mapping: {
       Date: 'Date',
       DateTime: 'Date',
       UUID: 'string',
     },
     debug: false,
+  },
+  // Typing for the GraphQL context
+  contextType: {
+    module: '@packages/data-context/src/DataContext.ts',
+    alias: 'ctx',
   },
 })
 ```


### PR DESCRIPTION
Well, according to the example shown [here](https://nexusjs.org/docs/api/make-schema#shouldgenerateartifacts-outputs-sourcetypes), the `contextType` attribute definition has been expecting to be passed inside of the attribute `sourceTypes` on `makeSchema`, But it doesn't work because the actually right place to use that should be directly on `makeSchema`, as such the own type definitions are expecting:

https://github.com/graphql-nexus/nexus/blob/5056129b4070c5ceb8a2a2e7c6244e01f0b9c897/src/builder.ts#L245

I didn't find any issue related to that, so I decided to create the PR directly without creating a new issue, just because it doesn't seem to be a big problem to be additionally discussed in another place, as long as it's not a big deal for the maintainers. But either way, I'm not quite sure about the contribution rules been used here once the CONTRIBUTING guide is empty and I couldn't find any other resourc to support me with that.

Anyways, I hope my disclaimer above was clear enough (:  