### PR TITLE
fix: correct edge node typing

### DIFF
--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -156,10 +156,9 @@ export interface ConnectionPluginConfig {
 }
 
 // Extract the node value from the connection for a given field.
-export type NodeValue<TypeName extends string = any, FieldName extends string = any> = ResultValue<
-  EdgeTypeLookup<TypeName, FieldName>,
-  'node'
->
+export type NodeValue<TypeName extends string = any, FieldName extends string = any> = SourceValue<
+  EdgeTypeLookup<TypeName, FieldName>
+>['node']
 
 export type ConnectionFieldConfig<TypeName extends string = any, FieldName extends string = any> = {
   type: GetGen<'allOutputTypes', string> | AllNexusNamedOutputTypeDefs


### PR DESCRIPTION
Needs a test, but currently the resolved value for `nodes` is incorrect if you specify a custom type for the connection edge.