### PR TITLE
chore(docs): update API link to Prisma object modeling 

### DIFF
--- a/docs/content/030-plugins/050-prisma/030-api.mdx
+++ b/docs/content/030-plugins/050-prisma/030-api.mdx
@@ -8,7 +8,7 @@ tocDepth: 2
 
 Only available within [`objectType`](/api/object-type) definitions.
 
-`t.model` contains configurable _field projectors_ that you use for projecting fields of your [Prisma models](https://github.com/prisma/prisma2/blob/master/docs/data-modeling.md#models) onto your [GraphQL Objects](https://graphql.github.io/graphql-spec/June2018/#sec-Objects). The precise behaviour of field projectors vary by the Prisma type being projected. Refer to the respective sub-sections for details.
+`t.model` contains configurable _field projectors_ that you use for projecting fields of your [Prisma models](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model) onto your [GraphQL Objects](https://graphql.github.io/graphql-spec/June2018/#sec-Objects). The precise behaviour of field projectors vary by the Prisma type being projected. Refer to the respective sub-sections for details.
 
 ### Model-object mapping
 


### PR DESCRIPTION
As of now, the new Prisma docs aren't availible on the GitHub anymore, and we have to go on the official Prisma website. This replaces the GitHub file link with the link on the official Prisma website.