### PR TITLE
chore(docs): fix proper variable name

### DIFF
--- a/docs/content/015-api/100-query-field.mdx
+++ b/docs/content/015-api/100-query-field.mdx
@@ -24,7 +24,7 @@ export const usersQueryField = queryField('user', {
 as shorthand for:
 
 ```ts
-export const createUser = extendType({
+export const usersQueryField = extendType({
   type: 'Query',
   definition(t) {
     t.field('user', {


### PR DESCRIPTION
Change the variable name appropriately in the example code
https://nexusjs.org/docs/api/query-field