### PR TITLE
Fix maybe deep promise type

### DIFF
--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -1,4 +1,5 @@
 import type { GraphQLAbstractType, GraphQLResolveInfo } from 'graphql'
+
 import type { NexusInterfaceTypeDef } from './definitions/interfaceType'
 import type { NexusObjectTypeDef } from './definitions/objectType'
 
@@ -35,8 +36,6 @@ export type MaybePromise<T> = PromiseLike<T> | T
  * use this to help signify that.
  */
 export type MaybePromiseDeep<T> = Date extends T
-  ? MaybePromise<T>
-  : null extends T
   ? MaybePromise<T>
   : boolean extends T
   ? MaybePromise<T>


### PR DESCRIPTION
Removing the conditional type for null in `MaybePromiseDeep` seems to fix the below linked issue without removing any type safety.
I've tested it with the getters for `edges` and `pageInfo` with and without promises.

However, I'm not entirely sure if this breaks something else as it seems to be a utility used in mutliple places across the library.

Closes #853﻿
