### PR TITLE
feat: Accept `ReadonlyArray<T>` for enum members

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -139,6 +139,7 @@ import {
   graphql15InterfaceConfig,
   graphql15InterfaceType,
   invariantGuard,
+  isArray,
   isObject,
   mapValues,
   objValues,
@@ -952,7 +953,7 @@ export class SchemaBuilder {
   private buildEnumType(config: NexusEnumTypeConfig<any>) {
     const { members } = config
     const values: GraphQLEnumValueConfigMap = {}
-    if (Array.isArray(members)) {
+    if (isArray(members)) {
       members.forEach((m) => {
         if (typeof m === 'string') {
           values[m] = { value: m }

--- a/src/definitions/enumType.ts
+++ b/src/definitions/enumType.ts
@@ -34,7 +34,7 @@ export interface NexusEnumTypeConfig<TypeName extends string> {
   sourceType?: SourceTypingDef
   /** All members of the enum, either as an array of strings/definition objects, as an object, or as a TypeScript enum */
   members:
-    | Array<string | EnumMemberInfo>
+    | ReadonlyArray<string | EnumMemberInfo>
     | Record<string, string | number | object | boolean>
     | TypeScriptEnumLike
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -600,3 +600,11 @@ export function graphql15InterfaceType<T extends GraphQLInterfaceType>(
   }
   return type as T & { getInterfaces(): GraphQLInterfaceType[] }
 }
+
+// A function that is correctly typed to get arround a TypeScript issue.
+// See https://github.com/microsoft/TypeScript/issues/17002
+export function isArray<T>(
+  arg: T | {}
+): arg is T extends readonly any[] ? (unknown extends T ? never : readonly any[]) : any[] {
+  return Array.isArray(arg)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -601,8 +601,9 @@ export function graphql15InterfaceType<T extends GraphQLInterfaceType>(
   return type as T & { getInterfaces(): GraphQLInterfaceType[] }
 }
 
-// A function that is correctly typed to get arround a TypeScript issue.
-// See https://github.com/microsoft/TypeScript/issues/17002
+/**
+ * A specially typed version of `Array.isArray` to work around [this issue](https://github.com/microsoft/TypeScript/issues/17002).
+ */
 export function isArray<T>(
   arg: T | {}
 ): arg is T extends readonly any[] ? (unknown extends T ? never : readonly any[]) : any[] {


### PR DESCRIPTION
Closes #455

I added in a new `isArray` util which just calls `Array.isArray` but correctly narrows the type of the input. This is to workaround the issue described [here](https://github.com/microsoft/TypeScript/issues/17002), the solution was taken from the since reverted https://github.com/microsoft/TypeScript/pull/39258