### PR TITLE
fix: plugin inputFieldDefTypes

### DIFF
--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -116,7 +116,8 @@ export type CommonInputFieldConfig<TypeName extends string, FieldName extends st
    * graphql-js based tools which rely on looking for special data here.
    */
   extensions?: GraphQLInputFieldConfig['extensions']
-} & NexusGenPluginFieldConfig<TypeName, FieldName>
+} & NexusGenPluginFieldConfig<TypeName, FieldName> &
+  NexusGenPluginInputFieldConfig<TypeName, FieldName>
 export interface OutputScalarConfig<TypeName extends string, FieldName extends string>
   extends CommonOutputFieldConfig<TypeName, FieldName> {
   /**


### PR DESCRIPTION
Fix plugins' `inputFieldDefTypes` not being propagated to CommonInputFieldConfig types. I've left the probably errorneous `NexusGenPluginFieldConfig` in for backward compatibility.