### PR TITLE
fix: Allow meta types to be wrapped with null/list

### DIFF
--- a/src/definitions/list.ts
+++ b/src/definitions/list.ts
@@ -1,4 +1,5 @@
 import { isType } from 'graphql'
+import { isNexusMeta } from './nexusMeta'
 import { AllNamedTypeDefs, isNexusStruct, NexusListableTypes } from './wrapping'
 import { NexusTypes, withNexusSymbol } from './_types'
 /** List() */
@@ -13,7 +14,12 @@ export class NexusListDef<TypeName extends NexusListableTypes> {
 
   constructor(readonly ofNexusType: TypeName) {
     /* istanbul ignore if */
-    if (typeof ofNexusType !== 'string' && !isNexusStruct(ofNexusType) && !isType(ofNexusType)) {
+    if (
+      typeof ofNexusType !== 'string' &&
+      !isNexusStruct(ofNexusType) &&
+      !isNexusMeta(ofNexusType) &&
+      !isType(ofNexusType)
+    ) {
       throw new Error('Cannot wrap unknown types in list(). Saw ' + ofNexusType)
     }
   }

--- a/src/definitions/nonNull.ts
+++ b/src/definitions/nonNull.ts
@@ -1,4 +1,5 @@
 import { isNonNullType, isType } from 'graphql'
+import { isNexusMeta } from './nexusMeta'
 import { isNexusNonNullTypeDef, isNexusNullTypeDef, isNexusStruct, NexusNonNullableTypes } from './wrapping'
 import { NexusTypes, withNexusSymbol } from './_types'
 
@@ -8,7 +9,12 @@ export class NexusNonNullDef<TypeName extends NexusNonNullableTypes> {
   private _isNexusNonNullDef: boolean = true
 
   constructor(readonly ofNexusType: TypeName) {
-    if (typeof ofNexusType !== 'string' && !isNexusStruct(ofNexusType) && !isType(ofNexusType)) {
+    if (
+      typeof ofNexusType !== 'string' &&
+      !isNexusStruct(ofNexusType) &&
+      !isNexusMeta(ofNexusType) &&
+      !isType(ofNexusType)
+    ) {
       throw new Error('Cannot wrap unknown types in a nonNull(). Saw ' + ofNexusType)
     }
   }

--- a/src/definitions/nullable.ts
+++ b/src/definitions/nullable.ts
@@ -1,4 +1,5 @@
 import { isType } from 'graphql'
+import { isNexusMeta } from './nexusMeta'
 import { isNexusNonNullTypeDef, isNexusNullTypeDef, isNexusStruct, NexusNullableTypes } from './wrapping'
 import { NexusTypes, withNexusSymbol } from './_types'
 
@@ -8,7 +9,12 @@ export class NexusNullDef<TypeName extends NexusNullableTypes> {
   private _isNexusNullDef: boolean = true
 
   constructor(readonly ofNexusType: TypeName) {
-    if (typeof ofNexusType !== 'string' && !isNexusStruct(ofNexusType) && !isType(ofNexusType)) {
+    if (
+      typeof ofNexusType !== 'string' &&
+      !isNexusStruct(ofNexusType) &&
+      !isNexusMeta(ofNexusType) &&
+      !isType(ofNexusType)
+    ) {
       throw new Error('Cannot wrap unknown types in nullable(). Saw ' + ofNexusType)
     }
   }

--- a/tests/definitions/nexusMeta.spec.ts
+++ b/tests/definitions/nexusMeta.spec.ts
@@ -1,10 +1,24 @@
 import { graphql } from 'graphql'
 import { makeSchema, objectType, queryField } from '../../src'
-import { NEXUS_BUILD, NEXUS_TYPE } from '../../src/core'
+import { list, NEXUS_BUILD, NEXUS_TYPE, nonNull, nullable } from '../../src/core'
 
 interface UserData {
   id?: string
   ok?: boolean
+}
+
+class Post {
+  static [NEXUS_TYPE]() {
+    return objectType({
+      name: 'Post',
+      definition(t) {
+        t.string('content')
+        t.field('author', {
+          type: 'User',
+        })
+      },
+    })
+  }
 }
 
 class User {
@@ -28,10 +42,16 @@ class User {
       definition(t) {
         t.id('id')
         t.boolean('ok')
-        t.field('info', { type: UserInfo })
+        t.field('info', { type: nonNull(UserInfo) })
         t.field('friend', {
           type: User,
           resolve: () => new User({ id: 'User:2', ok: false }),
+        })
+        t.field('posts', {
+          type: list(Post),
+        })
+        t.field('topPost', {
+          type: nullable(Post),
         })
       },
     })


### PR DESCRIPTION
Continuing on #934, allows meta types to be used within type wrappers