### PR TITLE
feat: field config with name

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12.x
       - name: Install Dependencies
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - name: Install Dependencies
         run: yarn --frozen-lockfile || yarn --frozen-lockfile
       - name: Prettier

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -58,7 +58,7 @@ jobs:
           # rm examples/star-wars/star-wars-schema.graphql
           # node examples/star-wars/dist/schema.js
           # git diff --exit-code
-        node-version: [10.x]
+        node-version: [12.x]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +57,7 @@ jobs:
           # rm examples/star-wars/star-wars-schema.graphql
           # node examples/star-wars/dist/schema.js
           # git diff --exit-code
-        node-version: [10.x]
+        node-version: [12.x]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12.x
       - name: Install Dependencies
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - name: Install Dependencies
         run: yarn --frozen-lockfile || yarn --frozen-lockfile
       - name: Release Canary

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "jest-watch-typeahead": "^0.6.1",
     "lint-staged": "^7.3.0",
     "patch-package": "6.2.2",
-    "prettier": "^2.2.1",
+    "prettier": "^2.3.1",
     "prettier-plugin-jsdoc": "^0.2.5",
     "sort-package-json": "^1.22.1",
     "ts-jest": "^26.4.4",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lint-staged": "^7.3.0",
     "patch-package": "6.2.2",
     "prettier": "^2.3.1",
-    "prettier-plugin-jsdoc": "^0.2.5",
+    "prettier-plugin-jsdoc": "^0.3.23",
     "sort-package-json": "^1.22.1",
     "ts-jest": "^26.4.4",
     "ts-morph": "^8.2.0",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -453,8 +453,8 @@ export class SchemaBuilder {
 
   /**
    * Add type takes a Nexus type, or a GraphQL type and pulls it into an internal "type registry". It also
-   * does an initial pass on any types that are referenced on the "types" field and pulls those in too, so
-   * you can define types anonymously, without exporting them.
+   * does an initial pass on any types that are referenced on the "types" field and pulls those in too, so you
+   * can define types anonymously, without exporting them.
    */
   addType = (typeDef: NexusAcceptedTypeDef) => {
     if (isNexusMeta(typeDef)) {

--- a/src/definitions/_types.ts
+++ b/src/definitions/_types.ts
@@ -175,15 +175,12 @@ export type NexusFeaturesInput = {
    * types guide](https://nxs.li/guides/abstract-types).
    *
    * If you plan on enabling multiple strategies and you've never done so then please [read the guide about
-   * using multiple strategies](https://nxs.li/guides/abstract-types/using-multiple-strategies) as there are
-   * a few quirks to be aware of.
+   * using multiple strategies](https://nxs.li/guides/abstract-types/using-multiple-strategies) as there are a
+   * few quirks to be aware of.
    *
-   * @default
-   *  {
-   *    resolveType: true,
+   * @default {resolveType: true,
    *    __typename: false
-   *    isTypeOf: false,
-   * }
+   *    isTypeOf: false,}
    */
   abstractTypeStrategies?: {
     /**
@@ -206,16 +203,16 @@ export type NexusFeaturesInput = {
      * the [Discriminant Model Field Strategy](https://nxs.li/guides/abstract-types/discriminant-model-field-strategy).
      *
      * Warning :: When this strategy is enabled in conjunction with other strategies the
-     * "abstractTypeRuntimeChecks" feature will automatically be disabled. This is because it is not
-     * practical at runtime to find out if resolvers will return objects that include the "__typename" field.
-     * This trade-off can be acceptable since the runtime checks are a redundant safety measure over the
-     * static typing. So as long as you are not ignoring static errors related to Nexus' abstract type type
-     * checks then you then you should still have a safe implementation.
+     * "abstractTypeRuntimeChecks" feature will automatically be disabled. This is because it is not practical
+     * at runtime to find out if resolvers will return objects that include the "__typename" field. This
+     * trade-off can be acceptable since the runtime checks are a redundant safety measure over the static
+     * typing. So as long as you are not ignoring static errors related to Nexus' abstract type type checks
+     * then you then you should still have a safe implementation.
      *
-     * Furthermore another effect is that statically the other strategies will not appear to be _required_,
-     * but instead _optional_, while only this one will appear required. However, upon implementing any of
-     * the other strategies, this one will not longer be required. This quirk is explained in the guide
-     * section about [using multiple strategies](https://nxs.li/guides/abstract-types/using-multiple-strategies).
+     * Furthermore another effect is that statically the other strategies will not appear to be *required*,
+     * but instead *optional*, while only this one will appear required. However, upon implementing any of the
+     * other strategies, this one will not longer be required. This quirk is explained in the guide section
+     * about [using multiple strategies](https://nxs.li/guides/abstract-types/using-multiple-strategies).
      */
     __typename?: boolean
   }

--- a/src/definitions/args.ts
+++ b/src/definitions/args.ts
@@ -53,7 +53,7 @@ export interface ScalarArgConfig<T> extends CommonArgConfig {
   /**
    * The default value for this argument when ***none*** is given by the client.
    *
-   * Note that _null_ is still considered something meaning if the client gives an explicit null that will
+   * Note that *null* is still considered something meaning if the client gives an explicit null that will
    * prevent the default from activating. This is why the type of an arg with a default value in the resolver
    * includes "undefined | null".
    *
@@ -87,10 +87,8 @@ export interface NexusArgConfig<T extends string> extends NexusAsArgConfig<T> {
    * Types may be expressed in one of three ways:
    *
    * 1. As string literals matching the name of a builtin scalar.
-   *
    * 2. As string literals matching the name of another type. Thanks to [Nexus' reflection
-   * system](https://nxs.li/guides/reflection) this is typesafe and autocompletable.
-   *
+   *    system](https://nxs.li/guides/reflection) this is typesafe and autocompletable.
    * 3. As references to other enums or input object type definitions.
    *
    * Type modifier helpers like list() may also be used and in turn accept one of the three methods listed above.
@@ -159,7 +157,7 @@ withNexusSymbol(NexusArgDef, NexusTypes.Arg)
  *   })
  *
  * @param config Configuration for the argument like its type and description. See jsdoc on each config field
- *     for details.
+ *   for details.
  */
 export function arg<T extends string>(config: NexusArgConfig<T>) {
   if (!config.type) {
@@ -193,8 +191,7 @@ export function arg<T extends string>(config: NexusArgConfig<T>) {
  *     },
  *   })
  *
- * @param config Configuration for the argument like its description. See jsdoc on each config field
- *     for details.
+ * @param config Configuration for the argument like its description. See jsdoc on each config field for details.
  */
 export function stringArg(config?: ScalarArgConfig<string>) {
   return arg({ type: 'String', ...config })
@@ -224,8 +221,7 @@ export function stringArg(config?: ScalarArgConfig<string>) {
  *     },
  *   })
  *
- * @param config Configuration for the argument like its description. See jsdoc on each config field
- *     for details.
+ * @param config Configuration for the argument like its description. See jsdoc on each config field for details.
  */
 export function intArg(config?: ScalarArgConfig<number>) {
   return arg({ type: 'Int', ...config })
@@ -255,8 +251,7 @@ export function intArg(config?: ScalarArgConfig<number>) {
  *     },
  *   })
  *
- * @param config Configuration for the argument like its description. See jsdoc on each config field
- *     for details.
+ * @param config Configuration for the argument like its description. See jsdoc on each config field for details.
  */
 export function floatArg(config?: ScalarArgConfig<number>) {
   return arg({ type: 'Float', ...config })
@@ -286,8 +281,7 @@ export function floatArg(config?: ScalarArgConfig<number>) {
  *     },
  *   })
  *
- * @param config Configuration for the argument like its description. See jsdoc on each config field
- *     for details.
+ * @param config Configuration for the argument like its description. See jsdoc on each config field for details.
  */
 export function idArg(config?: ScalarArgConfig<string>) {
   return arg({ type: 'ID', ...config })
@@ -317,8 +311,7 @@ export function idArg(config?: ScalarArgConfig<string>) {
  *     },
  *   })
  *
- * @param config Configuration for the argument like its description. See jsdoc on each config field
- *     for details.
+ * @param config Configuration for the argument like its description. See jsdoc on each config field for details.
  */
 export function booleanArg(config?: ScalarArgConfig<boolean>) {
   return arg({ type: 'Boolean', ...config })

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -688,6 +688,31 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *   resolver, and more. See jsdoc on each field within for details.
    */
   field<FieldName extends string>(name: FieldName, config: FieldOutConfig<TypeName, FieldName>): void
+  /**
+   * [GraphQL 2018 Spec](https://spec.graphql.org/June2018/#sec-Language.Fields)
+   *
+   * Define a field on this object.
+   *
+   * A field describes one discrete piece of information available to request within a [selection
+   * set](https://spec.graphql.org/June2018/#sec-Selection-Sets). They are in fact most of what any selection
+   * set will contain. Fields can be typed as scalars (marking the terminal point of a branch of a selection
+   * set) or as other object types in your schema thus allowing you to model relationships between things.
+   *
+   * @example
+   *   objectType({
+   *     name: 'User',
+   *     definition(t) {
+   *       t.field({
+   *         name: 'id',
+   *         type: id(),
+   *         description: 'The unique identification number for this user',
+   *       })
+   *     },
+   *   })
+   *
+   * @param config The configuration for things like the field's type, its description, its arguments, its
+   *   resolver, and more. See jsdoc on each field within for details.
+   */
   field<FieldName extends string>(config: FieldOutConfigWithName<TypeName, FieldName>): void
   field<FieldName extends string>(
     ...args:

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -707,13 +707,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
       | [name: FieldName, config: FieldOutConfig<TypeName, FieldName>]
       | [config: FieldOutConfigWithName<TypeName, FieldName>]
   ): void {
-    let config: FieldOutConfigWithName<TypeName, FieldName> =
-      args.length === 2
-        ? {
-            name: args[0],
-            ...args[1],
-          }
-        : args[0]
+    const config = args.length === 2 ? { name: args[0], ...args[1] } : args[0]
 
     this.typeBuilder.addField({
       ...config,
@@ -833,13 +827,7 @@ export class InputDefinitionBlock<TypeName extends string> {
       | [FieldName, NexusInputFieldConfig<TypeName, FieldName>]
       | [NexusInputFieldConfigWithName<TypeName, FieldName>]
   ): void {
-    let config: NexusInputFieldConfigWithName<TypeName, FieldName> =
-      args.length === 2
-        ? {
-            name: args[0],
-            ...args[1],
-          }
-        : args[0]
+    const config = args.length === 2 ? { name: args[0], ...args[1] } : args[0]
 
     this.typeBuilder.addField({
       ...config,

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -128,9 +128,7 @@ export interface OutputScalarConfig<TypeName extends string, FieldName extends s
    * explicitly implement every resolver however. If the [source typing](https://nxs.li/guides/backing-types) includes:
    *
    * 1. A field whose name matches this one
-   *
    * 2. And whose type is compatible
-   *
    * 3. And is a scalar
    *
    * ...then the default resolver will be available, whose behaviour is to simply return that field from the
@@ -149,29 +147,29 @@ export interface OutputScalarConfig<TypeName extends string, FieldName extends s
    *   })
    *
    * @param source The [source data](https://nxs.li/guides/source-types) for the GraphQL object that this
-   *     field belongs to, unless this is a root
-   *     field (any field on a [root
-   *     operation type](https://spec.graphql.org/June2018/#sec-Root-Operation-Types): Query, Mutation,
-   *     Subscription), in which case there is no source data and this will be undefined.
+   *   field belongs to, unless this is a root field (any field on a [root operation
+   *   type](https://spec.graphql.org/June2018/#sec-Root-Operation-Types): Query, Mutation, Subscription), in
+   *   which case there is no source data and this will be undefined.
    * @param args If you have defined arguments on this field then this parameter will contain any arguments
-   *     passed by the client. If you specified default values for any arguments and the client did not explicitly
-   *     pass _any_ value (including null) for those arguments then you will see the defaults here.
+   *   passed by the client. If you specified default values for any arguments and the client did not
+   *   explicitly pass *any* value (including null) for those arguments then you will see the defaults here.
    *
-   * Note that thanks to [Nexus' reflection system](https://nxs.li/guides/reflection) this parameter's type
-   *     will always be type safe.
+   *   Note that thanks to [Nexus' reflection system](https://nxs.li/guides/reflection) this parameter's type
+   *   will always be type safe.
    * @param context The context data for this request.
    *
-   * The context data is typically a singleton scoped to the lifecycle of the request. This means created at
-   *     the beginning of a request and then passed to all the resolvers that execute while resolving the request.
-   *     It is often used to store information like the current user making the request. Nexus is not responsible
-   *     for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
-   *     [Apollo Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
+   *   The context data is typically a singleton scoped to the lifecycle of the request. This means created at
+   *   the beginning of a request and then passed to all the resolvers that execute while resolving the
+   *   request. It is often used to store information like the current user making the request. Nexus is not
+   *   responsible for this however. That is typically something you'll do with e.g.
+   *   [Mercurius](https://mercurius.dev) or [Apollo
+   *   Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
    *
-   * Note that the type here will be whatever you have specified for "contextType" in your makeSchema configuration.
+   *   Note that the type here will be whatever you have specified for "contextType" in your makeSchema configuration.
    * @param info The GraphQL resolve info.
    *
-   * This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
-   *     document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
+   *   This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
+   *   document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
    */
   resolve?: FieldResolver<TypeName, FieldName>
 }
@@ -429,7 +427,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
    * Guide](https://nexusjs.org/docs/guides/nullability) | [GraphQL 2018
    * Spec](https://spec.graphql.org/June2018/#sec-Type-System.Non-Null)
    *
-   * Chain this property to _unwrap_ the right-hand-side type (the field type or a list) of a Non-Null type.
+   * Chain this property to *unwrap* the right-hand-side type (the field type or a list) of a Non-Null type.
    *
    * In Nexus output types are nullable by default so this is only useful when you have changed your
    * nonNullDefaults configuration either globally in your makeSchema config or at the type definition level
@@ -477,7 +475,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * This is a shorthand equivalent to:
    *
-   * ` t.field('...', { type: boolean() }) `
+   * `t.field('...', { type: boolean() })`
    *
    * @example
    *   objectType({
@@ -489,19 +487,17 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * @param name The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
    * @param config The configuration for things like the field's type, its description, its arguments, its
-   *     resolver, and more. See jsdoc on each field within for details.
+   *   resolver, and more. See jsdoc on each field within for details.
    *
-   * This parameter is optional if no resolver is required. No resolver is required if the [source
-   *     typing](https://nxs.li/guides/backing-types):
+   *   This parameter is optional if no resolver is required. No resolver is required if the [source
+   *   typing](https://nxs.li/guides/backing-types):
    *
-   * 1. Has a field whose name matches this one
+   *   1. Has a field whose name matches this one
+   *   2. And whose type is compatible
+   *   3. And is a scalar
    *
-   * 2. And whose type is compatible
-   *
-   * 3. And is a scalar
-   *
-   * ...in which case the default resolver will be available whose behaviour is to simply return that field from the
-   *     received source type.
+   *   ...in which case the default resolver will be available whose behaviour is to simply return that field
+   *   from the received source type.
    */
   boolean<FieldName extends string>(name: FieldName, ...config: ScalarOutSpread<TypeName, FieldName>) {
     this.addScalarField(name, 'Boolean', config)
@@ -519,7 +515,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * This is a shorthand, equivalent to:
    *
-   * ` t.field('...', { type: string() }) `
+   * `t.field('...', { type: string() })`
    *
    * @example
    *   objectType({
@@ -531,19 +527,17 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * @param name The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
    * @param config The configuration for things like the field's type, its description, its arguments, its
-   *     resolver, and more. See jsdoc on each field within for details.
+   *   resolver, and more. See jsdoc on each field within for details.
    *
-   * This parameter is optional if no resolver is required. No resolver is required if the [source
-   *     typing](https://nxs.li/guides/backing-types):
+   *   This parameter is optional if no resolver is required. No resolver is required if the [source
+   *   typing](https://nxs.li/guides/backing-types):
    *
-   * 1. Has a field whose name matches this one
+   *   1. Has a field whose name matches this one
+   *   2. And whose type is compatible
+   *   3. And is a scalar
    *
-   * 2. And whose type is compatible
-   *
-   * 3. And is a scalar
-   *
-   * ...in which case the default resolver will be available whose behaviour is to simply return that field from the
-   *     received source type.
+   *   ...in which case the default resolver will be available whose behaviour is to simply return that field
+   *   from the received source type.
    */
   string<FieldName extends string>(name: FieldName, ...config: ScalarOutSpread<TypeName, FieldName>) {
     this.addScalarField(name, 'String', config)
@@ -562,7 +556,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * This is a shorthand, equivalent to:
    *
-   * ` t.field('...', { type: id() }) `
+   * `t.field('...', { type: id() })`
    *
    * @example
    *   objectType({
@@ -574,19 +568,17 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * @param name The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
    * @param config The configuration for things like the field's type, its description, its arguments, its
-   *     resolver, and more. See jsdoc on each field within for details.
+   *   resolver, and more. See jsdoc on each field within for details.
    *
-   * This parameter is optional if no resolver is required. No resolver is required if the [source
-   *     typing](https://nxs.li/guides/backing-types):
+   *   This parameter is optional if no resolver is required. No resolver is required if the [source
+   *   typing](https://nxs.li/guides/backing-types):
    *
-   * 1. Has a field whose name matches this one
+   *   1. Has a field whose name matches this one
+   *   2. And whose type is compatible
+   *   3. And is a scalar
    *
-   * 2. And whose type is compatible
-   *
-   * 3. And is a scalar
-   *
-   * ...in which case the default resolver will be available whose behaviour is to simply return that field from the
-   *     received source type.
+   *   ...in which case the default resolver will be available whose behaviour is to simply return that field
+   *   from the received source type.
    */
   id<FieldName extends string>(name: FieldName, ...config: ScalarOutSpread<TypeName, FieldName>) {
     this.addScalarField(name, 'ID', config)
@@ -603,7 +595,7 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * This is a shorthand equivalent to:
    *
-   * ` t.field('...', { type: int() }) `
+   * `t.field('...', { type: int() })`
    *
    * @example
    *   objectType({
@@ -615,19 +607,17 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * @param name The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
    * @param config The configuration for things like the field's type, its description, its arguments, its
-   *     resolver, and more. See jsdoc on each field within for details.
+   *   resolver, and more. See jsdoc on each field within for details.
    *
-   * This parameter is optional if no resolver is required. No resolver is required if the [source
-   *     typing](https://nxs.li/guides/backing-types):
+   *   This parameter is optional if no resolver is required. No resolver is required if the [source
+   *   typing](https://nxs.li/guides/backing-types):
    *
-   * 1. Has a field whose name matches this one
+   *   1. Has a field whose name matches this one
+   *   2. And whose type is compatible
+   *   3. And is a scalar
    *
-   * 2. And whose type is compatible
-   *
-   * 3. And is a scalar
-   *
-   * ...in which case the default resolver will be available whose behaviour is to simply return that field from the
-   *     received source type.
+   *   ...in which case the default resolver will be available whose behaviour is to simply return that field
+   *   from the received source type.
    */
   int<FieldName extends string>(name: FieldName, ...config: ScalarOutSpread<TypeName, FieldName>) {
     this.addScalarField(name, 'Int', config)
@@ -639,13 +629,12 @@ export class OutputDefinitionBlock<TypeName extends string> {
    * Define a field whose type is Float.
    *
    * Float types are [scalars](https://spec.graphql.org/June2018/#sec-Scalars) representing signed
-   * double‐precision fractional values as specified by IEEE 754. They are represented in JavaScript using
-   * the [number primitive
-   * type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number).
+   * double‐precision fractional values as specified by IEEE 754. They are represented in JavaScript using the
+   * [number primitive type](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number).
    *
    * This is a shorthand, equivalent to:
    *
-   * ` t.field('...', { type: float() }) `
+   * `t.field('...', { type: float() })`
    *
    * @example
    *   objectType({
@@ -657,19 +646,17 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *
    * @param name The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
    * @param config The configuration for things like the field's type, its description, its arguments, its
-   *     resolver, and more. See jsdoc on each field within for details.
+   *   resolver, and more. See jsdoc on each field within for details.
    *
-   * This parameter is optional if no resolver is required. No resolver is required if the [source
-   *     typing](https://nxs.li/guides/backing-types):
+   *   This parameter is optional if no resolver is required. No resolver is required if the [source
+   *   typing](https://nxs.li/guides/backing-types):
    *
-   * 1. Has a field whose name matches this one
+   *   1. Has a field whose name matches this one
+   *   2. And whose type is compatible
+   *   3. And is a scalar
    *
-   * 2. And whose type is compatible
-   *
-   * 3. And is a scalar
-   *
-   * ...in which case the default resolver will be available whose behaviour is to simply return that field from the
-   *     received source type.
+   *   ...in which case the default resolver will be available whose behaviour is to simply return that field
+   *   from the received source type.
    */
   float<FieldName extends string>(name: FieldName, ...config: ScalarOutSpread<TypeName, FieldName>) {
     this.addScalarField(name, 'Float', config)
@@ -697,8 +684,8 @@ export class OutputDefinitionBlock<TypeName extends string> {
    *   })
    *
    * @param name The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
-   * @param config The configuration for things like the field's type, its description, its arguments,
-   *     its resolver, and more. See jsdoc on each field within for details.
+   * @param config The configuration for things like the field's type, its description, its arguments, its
+   *   resolver, and more. See jsdoc on each field within for details.
    */
   field<FieldName extends string>(name: FieldName, config: FieldOutConfig<TypeName, FieldName>): void
   field<FieldName extends string>(config: FieldOutConfigWithName<TypeName, FieldName>): void

--- a/src/definitions/extendType.ts
+++ b/src/definitions/extendType.ts
@@ -21,8 +21,8 @@ export interface NexusExtendTypeConfig<TypeName extends string> {
    * "definition" method.
    *
    * @param t The type builder. Usually the same as that passed to objectType "definition" method except if
-   *     extending the Subscription type in which case you get a subscription type builder (which differs
-   *     slightly in that it requires implementation of a "subscribe" method on field configurations).
+   *   extending the Subscription type in which case you get a subscription type builder (which differs
+   *   slightly in that it requires implementation of a "subscribe" method on field configurations).
    */
   definition(
     t: IsSubscriptionType<TypeName> extends true ? SubscriptionBuilder : ObjectDefinitionBlock<TypeName>
@@ -57,10 +57,10 @@ withNexusSymbol(NexusExtendTypeDef, NexusTypes.ExtendObject)
  * use-case is so common Nexus ships dedicated functions for it: queryField, mutationField, subscriptionField.
  *
  * You can extend types before defining them strictly with objectType or the root field functions (queryType
- * etc.). The typing for "type" property will appear to suggest that you cannot, however once Nexus
- * reflection has run you'll see that the type you "extended" exists in the schema and that your static
- * typing error has been resolved. This behaviour is a convenience especially when extending root types which
- * you might never define in your schema directly.
+ * etc.). The typing for "type" property will appear to suggest that you cannot, however once Nexus reflection
+ * has run you'll see that the type you "extended" exists in the schema and that your static typing error has
+ * been resolved. This behaviour is a convenience especially when extending root types which you might never
+ * define in your schema directly.
  *
  * @example
  *   // types/User.ts
@@ -85,8 +85,8 @@ withNexusSymbol(NexusExtendTypeDef, NexusTypes.ExtendObject)
  *     },
  *   })
  *
- * @param config The specification of which type to extend and how. This is basically a subset of the configuration
- *     object passed to the objectType function.
+ * @param config The specification of which type to extend and how. This is basically a subset of the
+ *   configuration object passed to the objectType function.
  */
 export function extendType<TypeName extends AllOutputTypesPossible>(config: NexusExtendTypeConfig<TypeName>) {
   return new NexusExtendTypeDef(config.type, { ...config, name: config.type }) as NexusExtendTypeDef<any>

--- a/src/definitions/mutationField.ts
+++ b/src/definitions/mutationField.ts
@@ -116,7 +116,7 @@ export function mutationField(
  *
  * @param name The name of the field on the Mutation type. Names are case‐sensitive and must conform to pattern:
  *
- *     [_A-Za-z][_0-9A-Za-z]*
+ *         [_A-Za-z][_0-9A-Za-z]*
  * @param config The same type of configuration you would pass to t.field("...", config)
  */
 export function mutationField<FieldName extends string>(

--- a/src/definitions/mutationField.ts
+++ b/src/definitions/mutationField.ts
@@ -114,9 +114,8 @@ export function mutationField(
  *     // ...
  *   })
  *
- * @param name The name of the field on the Mutation type. Names are case‐sensitive and must conform to pattern:
- *
- *         [_A-Za-z][_0-9A-Za-z]*
+ * @param name The name of the field on the Mutation type. Names are case‐sensitive and must conform to
+ *   pattern: `[_A-Za-z][_0-9A-Za-z]*`
  * @param config The same type of configuration you would pass to t.field("...", config)
  */
 export function mutationField<FieldName extends string>(

--- a/src/definitions/mutationType.ts
+++ b/src/definitions/mutationType.ts
@@ -37,7 +37,7 @@ import { NexusObjectTypeConfig, objectType } from './objectType'
  *   })
  *
  * @param config Specify your Mutation type's fields, description, and more. See each config property's jsDoc
- *     for more detail.
+ *   for more detail.
  */
 export function mutationType(config: Omit<NexusObjectTypeConfig<'Mutation'>, 'name'>) {
   return objectType({ ...config, name: 'Mutation' })

--- a/src/definitions/nonNull.ts
+++ b/src/definitions/nonNull.ts
@@ -60,16 +60,13 @@ withNexusSymbol(NexusNonNullDef, NexusTypes.NonNull)
  *
  * @param type The type to wrap in Non-Null. This may be expressed in one of three ways:
  *
- * 1. As string literals matching the name of a builtin scalar. E.g.: 'ID', 'String', ...
+ *   1. As string literals matching the name of a builtin scalar. E.g.: 'ID', 'String', ...
+ *   2. As string literals matching the name of another type. E.g.: 'User', 'Location', ... Thanks to [Nexus'
+ *        reflection system](https://nxs.li/guides/reflection) this is typesafe and autocompletable. This is
+ *        the idiomatic approach in Nexus because it avoids excessive importing and circular references.
+ *   3. As references to other enums or object type definitions. E.g.: User, Location
  *
- * 2. As string literals matching the name of another type. E.g.: 'User', 'Location', ... Thanks to
- *     [Nexus' reflection
- *     system](https://nxs.li/guides/reflection) this is typesafe and autocompletable. This is the idiomatic
- *     approach in Nexus because it avoids excessive importing and circular references.
- *
- * 3. As references to other enums or object type definitions. E.g.: User, Location
- *
- * You may also use other type modifier helpers like list() which in turn accept one of the three
+ *   You may also use other type modifier helpers like list() which in turn accept one of the three
  */
 export function nonNull<TypeName extends NexusNonNullableTypes>(type: TypeName) {
   if (isNexusNonNullTypeDef(type) || isNonNullType(type)) {

--- a/src/definitions/nullable.ts
+++ b/src/definitions/nullable.ts
@@ -64,16 +64,13 @@ withNexusSymbol(NexusNullDef, NexusTypes.Null)
  *
  * @param type The type to wrap in Non-Null. This may be expressed in one of three ways:
  *
- * 1. As string literals matching the name of a builtin scalar. E.g.: 'ID', 'String', ...
+ *   1. As string literals matching the name of a builtin scalar. E.g.: 'ID', 'String', ...
+ *   2. As string literals matching the name of another type. E.g.: 'User', 'Location', ... Thanks to [Nexus'
+ *        reflection system](https://nxs.li/guides/reflection) this is typesafe and autocompletable. This is
+ *        the idiomatic approach in Nexus because it avoids excessive importing and circular references.
+ *   3. As references to other enums or object type definitions. E.g.: User, Location
  *
- * 2. As string literals matching the name of another type. E.g.: 'User', 'Location', ... Thanks to
- *     [Nexus' reflection
- *     system](https://nxs.li/guides/reflection) this is typesafe and autocompletable. This is the idiomatic
- *     approach in Nexus because it avoids excessive importing and circular references.
- *
- * 3. As references to other enums or object type definitions. E.g.: User, Location
- *
- * You may also use other type modifier helpers like list() which in turn accept one of the three
+ *   You may also use other type modifier helpers like list() which in turn accept one of the three
  */
 export function nullable<TypeName extends NexusNullableTypes>(type: TypeName) {
   if (isNexusNonNullTypeDef(type)) {

--- a/src/definitions/objectType.ts
+++ b/src/definitions/objectType.ts
@@ -118,8 +118,8 @@ export type NexusObjectTypeConfig<TypeName extends string> = {
    *
    * @example
    *   {
-   *   module: 'some-package',
-   *   export: 'User',
+   *     "module": "some-package",
+   *     "export": "User"
    *   }
    *
    * @example
@@ -162,13 +162,12 @@ export type NexusObjectTypeConfig<TypeName extends string> = {
    * Define the fields of your object type.
    *
    * This method receives a type builder api that you will use to define the fields of your object type
-   * within. You can leverage conditionals, loops, other functions (that take the builder api as an
-   * argument), pull in variables from higher scopes, and so on, to help define your fields. However avoid two things:
+   * within. You can leverage conditionals, loops, other functions (that take the builder api as an argument),
+   * pull in variables from higher scopes, and so on, to help define your fields. However avoid two things:
    *
    * 1. Doing asynchronous work when defining fields.
-   *
-   * 2. Triggering side-effects that you would NOT want run at _build_ time––as this code will run during
-   * build to support [Nexus' reflection system](https://nxs.li/guides/reflection).
+   * 2. Triggering side-effects that you would NOT want run at *build* time––as this code will run during build
+   *    to support [Nexus' reflection system](https://nxs.li/guides/reflection).
    *
    * @example
    *   objectType({
@@ -186,8 +185,8 @@ export type NexusObjectTypeConfig<TypeName extends string> = {
    *   })
    *
    * @param t The type builder API for object types. The primary method you'll find is "t.field" but there are
-   *     many convenient shorthands available as well, plus anything plugins have added. Explore each one's jsDoc
-   *     for more detail.
+   *   many convenient shorthands available as well, plus anything plugins have added. Explore each one's
+   *   jsDoc for more detail.
    */
   definition(t: ObjectDefinitionBlock<TypeName>): void
 } & AbstractTypes.MaybeTypeDefConfigFieldIsTypeOf<TypeName> &

--- a/src/definitions/queryField.ts
+++ b/src/definitions/queryField.ts
@@ -102,7 +102,7 @@ export function queryField(
  *
  * @param name The name of the field on the Query type. Names are case‐sensitive and must conform to pattern:
  *
- *     [_A-Za-z][_0-9A-Za-z]*
+ *         [_A-Za-z][_0-9A-Za-z]*
  * @param config The same type of configuration you would pass to t.field("...", config)
  */
 export function queryField<FieldName extends string>(

--- a/src/definitions/queryField.ts
+++ b/src/definitions/queryField.ts
@@ -101,8 +101,7 @@ export function queryField(
  *   })
  *
  * @param name The name of the field on the Query type. Names are case‐sensitive and must conform to pattern:
- *
- *         [_A-Za-z][_0-9A-Za-z]*
+ *   `[_A-Za-z][_0-9A-Za-z]*`
  * @param config The same type of configuration you would pass to t.field("...", config)
  */
 export function queryField<FieldName extends string>(

--- a/src/definitions/queryType.ts
+++ b/src/definitions/queryType.ts
@@ -36,8 +36,8 @@ import { NexusObjectTypeConfig, objectType } from './objectType'
  *     },
  *   })
  *
- * @param config Specify your Query type's fields, description, and more. See each config property's jsDoc
- *     for more detail.
+ * @param config Specify your Query type's fields, description, and more. See each config property's jsDoc for
+ *   more detail.
  */
 export function queryType(config: Omit<NexusObjectTypeConfig<'Query'>, 'name'>) {
   return objectType({ ...config, name: 'Query' })

--- a/src/definitions/subscriptionField.ts
+++ b/src/definitions/subscriptionField.ts
@@ -222,8 +222,7 @@ export function subscriptionField(
  *   })
  *
  * @param name The name of the field on the Query type. Names are case‐sensitive and must conform to pattern:
- *
- *         [_A-Za-z][_0-9A-Za-z]*
+ *   `[_A-Za-z][_0-9A-Za-z]*`
  * @param config The same type of configuration you would pass to t.field("...", config)
  */
 export function subscriptionField<FieldName extends string, Event>(

--- a/src/definitions/subscriptionField.ts
+++ b/src/definitions/subscriptionField.ts
@@ -15,16 +15,16 @@ export type SubscriptionFieldConfig<FieldName extends string, Event> =
  * `extendType({ type: 'Subscription' })`
  *
  * The Subscription type is one of three [root
- * types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types) in GraphQL and its fields represent
- * API operations your clients can run to be pushed data changes over time.
+ * types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types) in GraphQL and its fields represent API
+ * operations your clients can run to be pushed data changes over time.
  *
  * Use this instead of subscriptionType if you are going to modularize your schema and thus be wanting to
  * contribute fields to the Subscription type from multiple modules. You do not have to have previously
  * defined a Query type before using this. If you haven't Nexus will create one automatically for you.
  *
  * Note that the main difference about Subscription type from other object types is that its field
- * configurations require a special "subscribe" method where you can return an asynchronous iterator.
- * Promises yielded by that iterator become available to the resolver in its first param, the source data.
+ * configurations require a special "subscribe" method where you can return an asynchronous iterator. Promises
+ * yielded by that iterator become available to the resolver in its first param, the source data.
  *
  * If you need to leverage plugins or define multiple fields then use the typeBuilder overload variant of this
  * function. Otherwise you may prefer to the field name/config variant.
@@ -126,16 +126,16 @@ export function subscriptionField(
  * `extendType({ type: 'Subscription' })`
  *
  * The Subscription type is one of three [root
- * types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types) in GraphQL and its fields represent
- * API operations your clients can run to be pushed data changes over time.
+ * types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types) in GraphQL and its fields represent API
+ * operations your clients can run to be pushed data changes over time.
  *
  * Use this instead of subscriptionType if you are going to modularize your schema and thus be wanting to
  * contribute fields to the Subscription type from multiple modules. You do not have to have previously
  * defined a Query type before using this. If you haven't Nexus will create one automatically for you.
  *
  * Note that the main difference about Subscription type from other object types is that its field
- * configurations require a special "subscribe" method where you can return an asynchronous iterator.
- * Promises yielded by that iterator become available to the resolver in its first param, the source data.
+ * configurations require a special "subscribe" method where you can return an asynchronous iterator. Promises
+ * yielded by that iterator become available to the resolver in its first param, the source data.
  *
  * If you need to leverage plugins or define multiple fields then use the typeBuilder overload variant of this
  * function. Otherwise you may prefer to the field name/config variant.
@@ -223,7 +223,7 @@ export function subscriptionField(
  *
  * @param name The name of the field on the Query type. Names are case‐sensitive and must conform to pattern:
  *
- *     [_A-Za-z][_0-9A-Za-z]*
+ *         [_A-Za-z][_0-9A-Za-z]*
  * @param config The same type of configuration you would pass to t.field("...", config)
  */
 export function subscriptionField<FieldName extends string, Event>(

--- a/src/definitions/subscriptionType.ts
+++ b/src/definitions/subscriptionType.ts
@@ -30,11 +30,17 @@ export type SubscriptionScalarConfig<FieldName extends string, Event> =
   & SubscriptionTypeConfigBase<FieldName, Event>
 
 // prettier-ignore
-export interface SubscriptionTypeConfig<FieldName extends string, Event>
-  extends SubscriptionScalarConfig<FieldName, Event>
-  {
-    type: GetGen<'allOutputTypes'> | AllNexusOutputTypeDefs
-  }
+export interface SubscriptionTypeConfig<FieldName extends string, Event> extends SubscriptionScalarConfig<FieldName, Event> {
+  type: GetGen<'allOutputTypes'> | AllNexusOutputTypeDefs
+}
+
+// prettier-ignore
+export interface SubscriptionTypeConfigWithName<FieldName extends string, Event> extends SubscriptionTypeConfig<FieldName, Event> {
+  /**
+   * The name of this field. Must conform to the regex pattern: [_A-Za-z][_0-9A-Za-z]*
+   */  
+  name: FieldName
+}
 
 // prettier-ignore
 export interface SubscriptionBuilder {
@@ -46,7 +52,8 @@ export interface SubscriptionBuilder {
   boolean<FieldName extends string, Event>(fieldName: FieldName, opts: SubscriptionScalarConfig<FieldName, Event>): void
   id<FieldName extends string, Event>(fieldName: FieldName, config: SubscriptionScalarConfig<FieldName, Event>): void
   float<FieldName extends string, Event>(fieldName: FieldName, config: SubscriptionScalarConfig<FieldName, Event>): void
-  field<FieldName extends string, Event>(name: FieldName, fieldConfig: SubscriptionTypeConfig<FieldName, Event>): void
+  field<FieldName extends string, Event>(config: SubscriptionTypeConfigWithName<FieldName, Event>): void
+  field<FieldName extends string, Event>(name: FieldName, config: SubscriptionTypeConfig<FieldName, Event>): void
 }
 
 export type SubscriptionTypeParams = {

--- a/src/definitions/subscriptionType.ts
+++ b/src/definitions/subscriptionType.ts
@@ -70,16 +70,16 @@ export type SubscriptionTypeParams = {
  * `objectType({ name: 'Subscription' })`
  *
  * The Subscription type is one of three [root
- * types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types) in GraphQL and its fields represent
- * API operations your clients can run to be pushed data changes over time.
+ * types](https://spec.graphql.org/June2018/#sec-Root-Operation-Types) in GraphQL and its fields represent API
+ * operations your clients can run to be pushed data changes over time.
  *
  * You can only have one of these in your schema. If you are going to modularize your schema and thus be
  * wanting to contribute fields to the Subscription type from multiple modules then use
  * [queryField](https://nxs.li/docs/api/subscription-field) intead.
  *
  * Note that the main difference about Subscription type from other object types is that its field
- * configurations require a special "subscribe" method where you can return an asynchronous iterator.
- * Promises yielded by that iterator become available to the resolver in its first param, the source data.
+ * configurations require a special "subscribe" method where you can return an asynchronous iterator. Promises
+ * yielded by that iterator become available to the resolver in its first param, the source data.
  *
  * @example
  *   // Contrived but simple self-contained example
@@ -172,8 +172,8 @@ export type SubscriptionTypeParams = {
  *     },
  *   })
  *
- * @param config Specify your Subscription type's fields, description, and more. See each config property's jsDoc
- *     for more detail.
+ * @param config Specify your Subscription type's fields, description, and more. See each config property's
+ *   jsDoc for more detail.
  */
 export function subscriptionType(config: SubscriptionTypeParams) {
   return objectType({ ...config, name: 'Subscription' } as any)

--- a/src/definitions/wrapping.ts
+++ b/src/definitions/wrapping.ts
@@ -185,9 +185,10 @@ export function isNexusPlugin(obj: any): obj is NexusPlugin {
 export type NexusWrapKind = 'NonNull' | 'Null' | 'List'
 export type NexusFinalWrapKind = 'NonNull' | 'List'
 
-export function unwrapGraphQLDef(
-  typeDef: GraphQLType
-): { namedType: GraphQLNamedType; wrapping: NexusFinalWrapKind[] } {
+export function unwrapGraphQLDef(typeDef: GraphQLType): {
+  namedType: GraphQLNamedType
+  wrapping: NexusFinalWrapKind[]
+} {
   const wrapping: NexusFinalWrapKind[] = []
   let namedType = typeDef
   while (isWrappingType(namedType)) {

--- a/src/dynamicMethod.ts
+++ b/src/dynamicMethod.ts
@@ -63,9 +63,9 @@ withNexusSymbol(DynamicOutputMethodDef, NexusTypes.DynamicOutputMethod)
  * Defines a new property on the object definition block for an output type, taking arbitrary input to define
  * additional types. See the connectionPlugin:
  *
- * T.connectionField('posts', { nullable: true, totalCount(root, args, ctx, info) {
- *     return ctx.user.getTotalPostCount(root.id, args) }, nodes(root, args, ctx, info) {
- *     return ctx.user.getPosts(root.id, args) } })
+ * T.connectionField('posts', { nullable: true, totalCount(root, args, ctx, info) { return
+ * ctx.user.getTotalPostCount(root.id, args) }, nodes(root, args, ctx, info) { return
+ * ctx.user.getPosts(root.id, args) } })
  */
 export function dynamicOutputMethod<T extends string>(config: DynamicOutputMethodConfig<T>) {
   return new DynamicOutputMethodDef(config.name, config)

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -1,6 +1,10 @@
 import { defaultFieldResolver, GraphQLFieldResolver, GraphQLResolveInfo } from 'graphql'
 import { ArgsRecord, intArg, stringArg } from '../definitions/args'
-import type { CommonFieldConfig, FieldOutConfig } from '../definitions/definitionBlocks'
+import type {
+  CommonFieldConfig,
+  FieldOutConfig,
+  FieldOutConfigWithName,
+} from '../definitions/definitionBlocks'
 import { NexusNonNullDef, nonNull } from '../definitions/nonNull'
 import { NexusNullDef, nullable } from '../definitions/nullable'
 import { ObjectDefinitionBlock, objectType } from '../definitions/objectType'
@@ -923,9 +927,16 @@ function mergeArgs(obj: object, fieldArgs: ArgsValue<any, any>): ArgsValue<any, 
  */
 function provideArgs(block: ObjectDefinitionBlock<any>, fn: () => void) {
   const fieldDef = block.field
-  block.field = function (fieldName, config) {
+  block.field = function (
+    ...args:
+      | [name: string, config: FieldOutConfig<any, string>]
+      | [config: FieldOutConfigWithName<any, string>]
+  ) {
+    let config = args.length === 2 ? { name: args[0], ...args[1] } : args[0]
+
     const { resolve = defaultFieldResolver } = config
-    fieldDef.call(this, fieldName, {
+
+    fieldDef.call(this, {
       ...config,
       resolve(root, args, ctx, info) {
         return resolve(root, mergeArgs(root, args), ctx, info)
@@ -938,9 +949,16 @@ function provideArgs(block: ObjectDefinitionBlock<any>, fn: () => void) {
 
 function provideSourceAndArgs(block: ObjectDefinitionBlock<any>, fn: () => void) {
   const fieldDef = block.field
-  block.field = function (fieldName, config) {
+  block.field = function (
+    ...args:
+      | [name: string, config: FieldOutConfig<any, string>]
+      | [config: FieldOutConfigWithName<any, string>]
+  ) {
+    let config = args.length === 2 ? { name: args[0], ...args[1] } : args[0]
+
     const { resolve = defaultFieldResolver } = config
-    fieldDef.call(this, fieldName, {
+
+    fieldDef.call(this, {
       ...config,
       resolve(root, args, ctx, info) {
         return resolve(root.__connectionSource, mergeArgs(root, args), ctx, info)

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -117,8 +117,8 @@ export interface ConnectionPluginConfig {
    * Any additional fields to make available to the connection type, beyond edges / pageInfo / nodes.
    *
    * Any fields defined extended on the Connection type will automatically receive the args from the
-   * connection. If the field also defines args, they will be merged with the args of the connection, with
-   * the extension's field args taking precedence if there is a conflict.
+   * connection. If the field also defines args, they will be merged with the args of the connection, with the
+   * extension's field args taking precedence if there is a conflict.
    */
   extendConnection?: Record<
     string,
@@ -303,8 +303,8 @@ export type ConnectionFieldConfig<TypeName extends string = any, FieldName exten
   | {
       /**
        * Implement the full resolve, including `edges` and `pageInfo`. Useful in more complex pagination
-       * cases, or if you want to use utilities from other libraries like GraphQL Relay JS, and only use
-       * Nexus for the construction and type-safety:
+       * cases, or if you want to use utilities from other libraries like GraphQL Relay JS, and only use Nexus
+       * for the construction and type-safety:
        *
        * Https://github.com/graphql/graphql-relay-js
        */

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -705,10 +705,8 @@ export function makeResolveFn(
   return (root, args: PaginationArgs, ctx, info) => {
     const { nodes: nodesResolve } = fieldConfig
     const { decodeCursor = base64Decode, encodeCursor = base64Encode } = pluginConfig
-    const {
-      pageInfoFromNodes = defaultPageInfoFromNodes,
-      cursorFromNode = defaultCursorFromNode,
-    } = mergedConfig
+    const { pageInfoFromNodes = defaultPageInfoFromNodes, cursorFromNode = defaultCursorFromNode } =
+      mergedConfig
     if (!nodesResolve) {
       return null
     }
@@ -802,10 +800,9 @@ export function makeResolveFn(
         })
 
         if (hasPromise) {
-          return Promise.all([
-            Promise.all(resolvedEdgeList),
-            Promise.all(resolvedNodeList),
-          ]).then(([edges, nodes]) => ({ edges, nodes }))
+          return Promise.all([Promise.all(resolvedEdgeList), Promise.all(resolvedNodeList)]).then(
+            ([edges, nodes]) => ({ edges, nodes })
+          )
         }
 
         return {

--- a/src/plugins/fieldAuthorizePlugin.ts
+++ b/src/plugins/fieldAuthorizePlugin.ts
@@ -50,16 +50,15 @@ export const defaultFormatError = ({ error }: FieldAuthorizePluginErrorConfig): 
 
 export const fieldAuthorizePlugin = (authConfig: FieldAuthorizePluginConfig = {}) => {
   const { formatError = defaultFormatError } = authConfig
-  const ensureError = (root: any, args: any, ctx: GetGen<'context'>, info: GraphQLResolveInfo) => (
-    error: Error
-  ) => {
-    const finalErr = formatError({ error, root, args, ctx, info })
-    if (finalErr instanceof Error) {
-      throw finalErr
+  const ensureError =
+    (root: any, args: any, ctx: GetGen<'context'>, info: GraphQLResolveInfo) => (error: Error) => {
+      const finalErr = formatError({ error, root, args, ctx, info })
+      if (finalErr instanceof Error) {
+        throw finalErr
+      }
+      console.error(`Non-Error value ${finalErr} returned from custom formatError in authorize plugin`)
+      throw new Error('Not authorized')
     }
-    console.error(`Non-Error value ${finalErr} returned from custom formatError in authorize plugin`)
-    throw new Error('Not authorized')
-  }
   let hasWarned = false
   return plugin({
     name: 'NexusAuthorize',

--- a/src/typeHelpersInternal.ts
+++ b/src/typeHelpersInternal.ts
@@ -38,7 +38,7 @@ export type RequiredDeeply<T> = DoRequireDeeply<Exclude<T, undefined>>
  * Represents a POJO. Prevents from allowing arrays and functions.
  *
  * @remarks
- *  TypeScript interfaces will not be considered sub-types.
+ *   TypeScript interfaces will not be considered sub-types.
  */
 export type PlainObject = {
   [x: string]: Primitive | object

--- a/src/typegenAbstractTypes.ts
+++ b/src/typegenAbstractTypes.ts
@@ -63,7 +63,7 @@ export type IsTypeOfHandler<TypeName extends string> = (
  * Get an object with the `isTypeOf` field if applicable for the given object Type.
  *
  * @remarks
- *  Intersect the result of this with other things to build up the final options for a type def.
+ *   Intersect the result of this with other things to build up the final options for a type def.
  */
 export type MaybeTypeDefConfigFieldIsTypeOf<TypeName extends string> =
   // is isTypeOf strategy disabled ?
@@ -121,23 +121,24 @@ export type MaybeTypeDefConfigFieldIsTypeOf<TypeName extends string> =
          *   })
          *
          * @param source The [source data](https://nxs.li/guides/source-types) for the GraphQL objects that
-         *     are members of the abstract types that this type is a member of. For example for some type A in two
-         *     union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would receive
-         *     source data from A, B, C, D, & E at runtime.
+         *   are members of the abstract types that this type is a member of. For example for some type A in
+         *   two union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would
+         *   receive source data from A, B, C, D, & E at runtime.
          * @param context The context data for this request.
          *
-         * The context data is typically a singleton scoped to the lifecycle of the request. This means created at
-         *     the beginning of a request and then passed to all the resolvers that execute while resolving the request.
-         *     It is often used to store information like the current user making the request. Nexus is not responsible
-         *     for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
-         *     [Apollo Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
+         *   The context data is typically a singleton scoped to the lifecycle of the request. This means
+         *   created at the beginning of a request and then passed to all the resolvers that execute while
+         *   resolving the request. It is often used to store information like the current user making the
+         *   request. Nexus is not responsible for this however. That is typically something you'll do with
+         *   e.g. [Mercurius](https://mercurius.dev) or [Apollo
+         *   Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
          *
-         * Note that the type here will be whatever you have specified for "contextType" in your makeSchema
-         *     configuration.
+         *   Note that the type here will be whatever you have specified for "contextType" in your makeSchema
+         *   configuration.
          * @param info The GraphQL resolve info.
          *
-         * This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
-         *     document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
+         *   This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
+         *   document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
          * @returns A boolean indicating if the received source data is of this type or not.
          */
         isTypeOf?: IsTypeOfHandler<TypeName>
@@ -199,23 +200,24 @@ export type MaybeTypeDefConfigFieldIsTypeOf<TypeName extends string> =
          *   })
          *
          * @param source The [source data](https://nxs.li/guides/source-types) for the GraphQL objects that
-         *     are members of the abstract types that this type is a member of. For example for some type A in two
-         *     union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would receive
-         *     source data from A, B, C, D, & E at runtime.
+         *   are members of the abstract types that this type is a member of. For example for some type A in
+         *   two union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would
+         *   receive source data from A, B, C, D, & E at runtime.
          * @param context The context data for this request.
          *
-         * The context data is typically a singleton scoped to the lifecycle of the request. This means created at
-         *     the beginning of a request and then passed to all the resolvers that execute while resolving the request.
-         *     It is often used to store information like the current user making the request. Nexus is not responsible
-         *     for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
-         *     [Apollo Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
+         *   The context data is typically a singleton scoped to the lifecycle of the request. This means
+         *   created at the beginning of a request and then passed to all the resolvers that execute while
+         *   resolving the request. It is often used to store information like the current user making the
+         *   request. Nexus is not responsible for this however. That is typically something you'll do with
+         *   e.g. [Mercurius](https://mercurius.dev) or [Apollo
+         *   Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
          *
-         * Note that the type here will be whatever you have specified for "contextType" in your makeSchema
-         *     configuration.
+         *   Note that the type here will be whatever you have specified for "contextType" in your makeSchema
+         *   configuration.
          * @param info The GraphQL resolve info.
          *
-         * This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
-         *     document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
+         *   This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
+         *   document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
          * @returns A boolean indicating if the received source data is of this type or not.
          */
         isTypeOf?: IsTypeOfHandler<TypeName>
@@ -276,23 +278,24 @@ export type MaybeTypeDefConfigFieldIsTypeOf<TypeName extends string> =
          *   })
          *
          * @param source The [source data](https://nxs.li/guides/source-types) for the GraphQL objects that
-         *     are members of the abstract types that this type is a member of. For example for some type A in two
-         *     union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would receive
-         *     source data from A, B, C, D, & E at runtime.
+         *   are members of the abstract types that this type is a member of. For example for some type A in
+         *   two union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would
+         *   receive source data from A, B, C, D, & E at runtime.
          * @param context The context data for this request.
          *
-         * The context data is typically a singleton scoped to the lifecycle of the request. This means created at
-         *     the beginning of a request and then passed to all the resolvers that execute while resolving the request.
-         *     It is often used to store information like the current user making the request. Nexus is not responsible
-         *     for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
-         *     [Apollo Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
+         *   The context data is typically a singleton scoped to the lifecycle of the request. This means
+         *   created at the beginning of a request and then passed to all the resolvers that execute while
+         *   resolving the request. It is often used to store information like the current user making the
+         *   request. Nexus is not responsible for this however. That is typically something you'll do with
+         *   e.g. [Mercurius](https://mercurius.dev) or [Apollo
+         *   Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
          *
-         * Note that the type here will be whatever you have specified for "contextType" in your makeSchema
-         *     configuration.
+         *   Note that the type here will be whatever you have specified for "contextType" in your makeSchema
+         *   configuration.
          * @param info The GraphQL resolve info.
          *
-         * This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
-         *     document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
+         *   This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
+         *   document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
          * @returns A boolean indicating if the received source data is of this type or not.
          */
         isTypeOf?: IsTypeOfHandler<TypeName>
@@ -343,23 +346,24 @@ export type MaybeTypeDefConfigFieldIsTypeOf<TypeName extends string> =
          *   })
          *
          * @param source The [source data](https://nxs.li/guides/source-types) for the GraphQL objects that
-         *     are members of the abstract types that this type is a member of. For example for some type A in two
-         *     union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would receive
-         *     source data from A, B, C, D, & E at runtime.
+         *   are members of the abstract types that this type is a member of. For example for some type A in
+         *   two union types whose members are A,B.C and A,D,E respectively then isTypeOf method for A would
+         *   receive source data from A, B, C, D, & E at runtime.
          * @param context The context data for this request.
          *
-         * The context data is typically a singleton scoped to the lifecycle of the request. This means created at
-         *     the beginning of a request and then passed to all the resolvers that execute while resolving the request.
-         *     It is often used to store information like the current user making the request. Nexus is not responsible
-         *     for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
-         *     [Apollo Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
+         *   The context data is typically a singleton scoped to the lifecycle of the request. This means
+         *   created at the beginning of a request and then passed to all the resolvers that execute while
+         *   resolving the request. It is often used to store information like the current user making the
+         *   request. Nexus is not responsible for this however. That is typically something you'll do with
+         *   e.g. [Mercurius](https://mercurius.dev) or [Apollo
+         *   Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
          *
-         * Note that the type here will be whatever you have specified for "contextType" in your makeSchema
-         *     configuration.
+         *   Note that the type here will be whatever you have specified for "contextType" in your makeSchema
+         *   configuration.
          * @param info The GraphQL resolve info.
          *
-         * This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
-         *     document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
+         *   This is an advanced parameter seldom used. It includes things like the AST of the [GraphQL
+         *   document](https://spec.graphql.org/June2018/#sec-Language.Document) sent by the client.
          * @returns A boolean indicating if the received source data is of this type or not.
          */
         isTypeOf: IsTypeOfHandler<TypeName>
@@ -369,7 +373,7 @@ export type MaybeTypeDefConfigFieldIsTypeOf<TypeName extends string> =
  * Get an object with the `resolveType` field if applicable for the given abstract Type.
  *
  * @remarks
- *  Intersect the result of this with other things to build up the final options for a type def.
+ *   Intersect the result of this with other things to build up the final options for a type def.
  */
 export type MaybeTypeDefConfigFieldResolveType<TypeName extends string> = IsFeatureEnabled2<
   'abstractTypeStrategies',

--- a/src/typegenAbstractTypes.ts
+++ b/src/typegenAbstractTypes.ts
@@ -42,9 +42,8 @@ export type AbstractTypeNames<TypeName extends string> = ConditionalKeys<
 >
 
 /** Returns whether all the abstract type names where TypeName is used have implemented `resolveType` */
-export type IsStrategyResolveTypeImplementedInAllAbstractTypes<
-  TypeName extends string
-> = AbstractTypeNames<TypeName> extends GetGen<'abstractsUsingStrategyResolveType'> ? true : false
+export type IsStrategyResolveTypeImplementedInAllAbstractTypes<TypeName extends string> =
+  AbstractTypeNames<TypeName> extends GetGen<'abstractsUsingStrategyResolveType'> ? true : false
 
 /** Returns whether all the members of an abstract type have implemented `isTypeOf` */
 export type IsStrategyIsTypeOfImplementedInAllMembers<AbstractTypeName extends string> = GetGen2<

--- a/src/typegenAutoConfig.ts
+++ b/src/typegenAutoConfig.ts
@@ -31,8 +31,7 @@ export interface SourceTypeModule {
    *
    * If not provided, the default implementation is:
    *
-   * (type) => [
-   *     new RegExp(`(?:interface|type|class|enum)\\s+(${type.name})\\W`, "g"), ]
+   * (type) => [ new RegExp(`(?:interface|type|class|enum)\\s+(${type.name})\\W`, "g"), ]
    */
   typeMatch?: (type: GraphQLNamedType, defaultRegex: RegExp) => RegExp | RegExp[]
   /**

--- a/src/typegenAutoConfig.ts
+++ b/src/typegenAutoConfig.ts
@@ -165,9 +165,8 @@ export function typegenAutoConfig(options: SourceTypesConfigOptions, contextType
           return null
         }
 
-        const importPath = (path.isAbsolute(pathOrModule)
-          ? relativePathTo(resolvedPath, outputPath)
-          : pathOrModule
+        const importPath = (
+          path.isAbsolute(pathOrModule) ? relativePathTo(resolvedPath, outputPath) : pathOrModule
         ).replace(typeScriptFileExtension, '')
 
         if (allImportsMap[alias] && allImportsMap[alias] !== importPath) {

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -57,14 +57,10 @@ interface TypegenInfoWithFile extends TypegenInfo {
 /**
  * We track and output a few main things:
  *
- * 1. "root" types, or the values that fill the first
- *     argument for a given object type
- *
+ * 1. "root" types, or the values that fill the first argument for a given object type
  * 2. "arg" types, the values that are arguments to output fields.
- *
- * 3. "return" types, the values returned from the resolvers... usually
- *     just list/nullable variations on the "root" types for other types
- *
+ * 3. "return" types, the values returned from the resolvers... usually just list/nullable variations on the
+ *    "root" types for other types
  * 4. The names of all types, grouped by type.
  *
  * - Non-scalar types will get a dedicated "Root" type associated with it

--- a/src/typegenTypeHelpers.ts
+++ b/src/typegenTypeHelpers.ts
@@ -100,20 +100,20 @@ export type FieldResolver<TypeName extends string, FieldName extends string> = (
   source: SourceValue<TypeName>,
   /**
    * If you have defined arguments on this field then this parameter will contain any arguments passed by the
-   * client. If you specified default values for any arguments and the client did not explicitly pass _any_
+   * client. If you specified default values for any arguments and the client did not explicitly pass *any*
    * value (including null) for those arguments then you will see the defaults here.
    *
    * Note that thanks to [Nexus' reflection system](https://nxs.li/guides/reflection) this parameter's type
-   *     will always be type safe.
+   * will always be type safe.
    */
   args: ArgsValue<TypeName, FieldName>,
   /**
    * The context data for this request.
    *
    * The context data is typically a singleton scoped to the lifecycle of the request. This means created at
-   *     the beginning of a request and then passed to all the resolvers that execute while resolving the request.
-   *     It is often used to store information like the current user making the request. Nexus is not responsible
-   *     for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
+   * the beginning of a request and then passed to all the resolvers that execute while resolving the request.
+   * It is often used to store information like the current user making the request. Nexus is not responsible
+   * for this however. That is typically something you'll do with e.g. [Mercurius](https://mercurius.dev) or
    * [Apollo Server](https://apollographql.com/docs/apollo-server/api/apollo-server).
    *
    * Note that the type here will be whatever you have specified for "contextType" in your makeSchema configuration.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -233,7 +233,7 @@ function nixifyPathSlashes(path: string): string {
  * Format a path so it is suitable to be used as a module import.
  *
  * - Implicitly relative is made explicitly relative - TypeScript file extension is stripped - Windows slashes
- * converted into *nix slashes
+ *   converted into *nix slashes
  *
  * Do not pass Node module IDs here as they will be treated as relative paths e.g. "react" "@types/react" etc.
  */

--- a/tests/__helpers/testApp.ts
+++ b/tests/__helpers/testApp.ts
@@ -59,11 +59,11 @@ type Settings = {
 /**
  * Test that the given app can be built by TypeScript without any type errors.
  *
- * - Nexus generateSchema will be run before TypeScript to ensure typegen is present. - By default looks for
- * an `__app.ts` entrypoint - All entrypoint exports are expected to be Nexus type definitions - Except the
- * optional export name "plugins" which is treated as an array of plugins for makeSchema - Outputs a
- * `__typegen.ts` typegen module - You must import the typegen module into your entrypoint module - If you
- * provide a `tsconfig.json` file in the root dir it will be used.
+ * - Nexus generateSchema will be run before TypeScript to ensure typegen is present. - By default looks for an
+ *   `__app.ts` entrypoint - All entrypoint exports are expected to be Nexus type definitions - Except the
+ *   optional export name "plugins" which is treated as an array of plugins for makeSchema - Outputs a
+ *   `__typegen.ts` typegen module - You must import the typegen module into your entrypoint module - If you
+ *   provide a `tsconfig.json` file in the root dir it will be used.
  */
 export function testApp(settings: Settings & HookSettings) {
   const name = settings?.name ?? 'app'

--- a/tests/__helpers/testApp.ts
+++ b/tests/__helpers/testApp.ts
@@ -1,7 +1,7 @@
 /// <reference path="../_setup.ts" />
 import { join, relative } from 'path'
 import { core } from '../../src'
-import { BuilderConfigInput } from '../../src/core'
+import type { BuilderConfigInput } from '../../src/core'
 
 const { generateSchema, typegenFormatPrettier } = core
 

--- a/tests/__snapshots__/definitions.spec.ts.snap
+++ b/tests/__snapshots__/definitions.spec.ts.snap
@@ -10,12 +10,15 @@ exports[`extendInputType should allow extending input objects 1`] = `
 exports[`extendType should allow adding types to the Query type 1`] = `
 Array [
   "user",
+  "user2",
   "post",
+  "post2",
 ]
 `;
 
 exports[`inputObjectType should output lists properly, #33 1`] = `
 "input AddToBasketInput {
   extras: [ExtraBasketInput]
+  extras2: [ExtraBasketInput]
 }"
 `;

--- a/tests/definitions.spec.ts
+++ b/tests/definitions.spec.ts
@@ -138,15 +138,15 @@ describe('objectType', () => {
         t.string('email', {
           description: 'The email of the person whos account this is',
         })
-        t.field('nestedList', {
-          type: list(nonNull(list('String'))),
-        })
+        t.field('nestedList', { type: list(nonNull(list('String'))) })
+        t.field({ name: 'nestedList2', type: list(nonNull(list('String'))) })
       },
     })
     const typeMap = buildTypes<{ Account: GraphQLObjectType }>([Account])
     const fields = typeMap.Account.getFields()
-    expect(Object.keys(fields).sort()).toEqual(['email', 'id', 'name', 'nestedList'])
+    expect(Object.keys(fields).sort()).toEqual(['email', 'id', 'name', 'nestedList', 'nestedList2'])
     expect(fields.nestedList.type.toString()).toEqual('[[String]!]')
+    expect(fields.nestedList2.type.toString()).toEqual('[[String]!]')
   })
 })
 
@@ -156,14 +156,14 @@ describe('extendType', () => {
       type: 'Query',
       definition(t) {
         t.field('user', { type: 'User', args: { id: idArg() } })
+        t.field({ name: 'user2', type: 'User', args: { id: idArg() } })
       },
     })
     const GetPost = extendType({
       type: 'Query',
       definition(t) {
-        t.field('post', {
-          type: PostObject,
-        })
+        t.field('post', { type: PostObject })
+        t.field({ name: 'post2', type: PostObject })
       },
     })
     expect(
@@ -187,6 +187,7 @@ describe('inputObjectType', () => {
         name: 'AddToBasketInput',
         definition(t) {
           t.list.field('extras', { type: 'ExtraBasketInput' })
+          t.list.field({ name: 'extras2', type: 'ExtraBasketInput' })
         },
       }),
     ])

--- a/tests/subscriptionType.spec.ts
+++ b/tests/subscriptionType.spec.ts
@@ -36,6 +36,16 @@ it('defines a field on the mutation type as shorthand', async () => {
               return event
             },
           })
+          t.field({
+            name: 'someField2',
+            type: 'Int',
+            subscribe() {
+              return mockStream(10, 0, (int) => int - 1)
+            },
+            resolve: (event) => {
+              return event
+            },
+          })
           t.int('someInt', {
             subscribe() {
               return mockStream(10, 0, (int) => int + 1)
@@ -90,6 +100,7 @@ it('defines a field on the mutation type as shorthand', async () => {
     type Subscription {
       someBoolean: Boolean
       someField: Int
+      someField2: Int
       someFields: [Int]
       someFloat: Float
       someID: ID
@@ -107,6 +118,14 @@ it('defines a field on the mutation type as shorthand', async () => {
         `
           subscription {
             someField
+          }
+        `
+      ).then(take(3)),
+      subscribe(
+        schema,
+        `
+          subscription {
+            someField2
           }
         `
       ).then(take(3)),
@@ -167,6 +186,23 @@ it('defines a field on the mutation type as shorthand', async () => {
         Object {
           "data": Object {
             "someField": -3,
+          },
+        },
+      ],
+      Array [
+        Object {
+          "data": Object {
+            "someField2": -1,
+          },
+        },
+        Object {
+          "data": Object {
+            "someField2": -2,
+          },
+        },
+        Object {
+          "data": Object {
+            "someField2": -3,
           },
         },
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5861,10 +5861,10 @@ prettier@^1.16.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
+  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
 
 pretty-format@^23.6.0:
   version "23.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1015,6 +1015,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/mdast@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
+  integrity sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1066,6 +1073,11 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
+"@types/unist@*", "@types/unist@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
+  integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -1562,6 +1574,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+binary-search-bounds@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz#125e5bd399882f71e6660d4bf1186384e989fba7"
+  integrity sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==
+
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -1785,6 +1802,21 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2005,10 +2037,10 @@ commander@^2.12.1, commander@^2.14.1, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-comment-parser@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.7.6.tgz#0e743a53c8e646c899a1323db31f6cd337b10f12"
-  integrity sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==
+comment-parser@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.5.tgz#453627ef8f67dbcec44e79a9bd5baa37f0bce9b2"
+  integrity sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -2190,6 +2222,13 @@ debug@^3.1.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
@@ -3737,6 +3776,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3791,6 +3843,11 @@ is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3872,6 +3929,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-installed-globally@^0.3.1:
   version "0.3.2"
@@ -4791,10 +4853,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linguist-languages@^7.11.1:
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.12.1.tgz#bf4928f25953ce3e00369cf956ac4d016923d55f"
-  integrity sha512-+2CmUIeNOvJ7MWn6MY5h7mpDcw62MjKjXKC1wH0zLYnDQnn/0/+j3LcWO0v4+M9Vh/yqbt0codmlA7Z82bDnLA==
+linguist-languages@^7.13.0:
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.15.0.tgz#a93bed6b93015d8133622cb05da6296890862bfa"
+  integrity sha512-qkSSNDjDDycZ2Wcw+GziNBB3nNo3ddYUInM/PL8Amgwbd9RQ/BKGj2/1d6mdxKgBFnUqZuaDbkIwkE4KUwwmtQ==
 
 lint-staged@^7.3.0:
   version "7.3.0"
@@ -5052,6 +5114,22 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
+mdast-util-from-markdown@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
+
 meow@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-7.0.1.tgz#1ed4a0a50b3844b451369c48362eb0515f04c1dc"
@@ -5080,6 +5158,14 @@ merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromark@~2.11.0:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
@@ -5208,7 +5294,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -5603,6 +5689,18 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-filepath@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
@@ -5848,13 +5946,15 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier-plugin-jsdoc@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.2.5.tgz#ad4eb1885c879f7a22db7cf53d0c1861344aadec"
-  integrity sha512-C4l3V2rk7Ppoc4SO0cwnKazZy596iRE9j5VvsJo43LxK2T08B1YFruugtsfLgtbGNGviWIl7btN7uNjFsAo0Qw==
+prettier-plugin-jsdoc@^0.3.23:
+  version "0.3.23"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.3.23.tgz#6b2ef20d3d301110d8f23b734e31a2871ea9e0c2"
+  integrity sha512-dHLzMG1oYARnYEbOC4RiJelcsV5tG6IaTzYr2dBey8cj6zzJZpTzhlm+Fc6c4SnSz3LRZCJVtGv42CulLlKKVw==
   dependencies:
-    comment-parser "^0.7.6"
-    linguist-languages "^7.11.1"
+    binary-search-bounds "^2.0.5"
+    comment-parser "^1.1.4"
+    linguist-languages "^7.13.0"
+    mdast-util-from-markdown "^0.8.5"
 
 prettier@^1.16.0:
   version "1.19.1"
@@ -7340,6 +7440,13 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+unist-util-stringify-position@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
+  integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
+  dependencies:
+    "@types/unist" "^2.0.2"
 
 universal-user-agent@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Before/After with [Nexus Prisma](https://github.com/prisma/nexus-prisma)
<img width="1024" alt="CleanShot 2021-06-23 at 15 59 28@2x" src="https://user-images.githubusercontent.com/284476/123160305-03189100-d43c-11eb-9ab7-b1b9777315eb.png">

<img width="1015" alt="CleanShot 2021-06-23 at 16 11 46@2x" src="https://user-images.githubusercontent.com/284476/123161719-c2ba1280-d43d-11eb-9758-ce95028c5ea2.png">


JSDoc:

<img width="915" alt="CleanShot 2021-06-23 at 15 58 59@2x" src="https://user-images.githubusercontent.com/284476/123160325-090e7200-d43c-11eb-925f-31379c50a8a2.png">

<img width="961" alt="CleanShot 2021-06-23 at 16 12 47@2x" src="https://user-images.githubusercontent.com/284476/123161822-e1200e00-d43d-11eb-822a-339239555565.png">

Incidental changes:

- Had to update prettier to parse TS named tuple syntax
- Updated JSDoc prettier plugin, seems better, noted one issue https://github.com/homer0/packages/issues/13 but it does not hit us hard, just three instances
- For updated JSDoc prettier plugin, had to drop us running Node 10.x. We should drop that anyways.
- formatting run on codebase, changes some stuff
- setup-node action was defaulting to using node v10, updated that