### PR TITLE
chore(docs): improve scalar documentation

### DIFF
--- a/docs/content/015-api/030-scalar-type.mdx
+++ b/docs/content/015-api/030-scalar-type.mdx
@@ -65,3 +65,14 @@ const SomeObject = objectType({
 ```
 
 Check the type-definitions or [the examples](https://github.com/graphql-nexus/nexus/tree/main/examples) for a full illustration of the various options for `scalarType`, or feel free to open a PR on the docs to help document!
+
+
+## Pass scalar to schema generation
+It's important to list the scalar in the `types` attribute of `makeSchema`
+
+```ts
+const schema = makeSchema({
+  types: [GQLDate] // Add Scalar to Array
+})
+```
+


### PR DESCRIPTION
I was messing around for ours to get a custom scalar working. I simply forgot to list in in the `types` array while creating the schema. There was no mention about this in the docs.

Thanks!