### PR TITLE
revert: "fix: #921 wrong typegen for nullable values w/ default"

### DIFF
--- a/patches/prettier-plugin-jsdoc+0.2.5.patch
+++ b/patches/prettier-plugin-jsdoc+0.2.5.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/prettier-plugin-jsdoc/lib/parser.js b/node_modules/prettier-plugin-jsdoc/lib/parser.js
+index 85b9e5d..3b98730 100644
+--- a/node_modules/prettier-plugin-jsdoc/lib/parser.js
++++ b/node_modules/prettier-plugin-jsdoc/lib/parser.js
+@@ -12,7 +12,7 @@ const stringify_1 = require("./stringify");
+ /** @link https://prettier.io/docs/en/api.html#custom-parser-api} */
+ exports.getParser = (parser) => function jsdocParser(text, parsers, options) {
+     const ast = parser(text, parsers, options);
+-    if (!options.jsdocParser) {
++    if (!options || !options.jsdocParser) {
+         return ast;
+     }
+     /**

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -16,7 +16,6 @@ import {
   isInterfaceType,
   isListType,
   isNonNullType,
-  isNullableType,
   isObjectType,
   isScalarType,
   isSpecifiedScalarType,
@@ -716,15 +715,15 @@ export class TypegenPrinter {
   }
 
   normalizeArg(arg: GraphQLInputField | GraphQLArgument): [string, string] {
-    return [this.argSeparator(arg.type, arg.defaultValue !== undefined), this.argTypeRepresentation(arg.type)]
+    return [this.argSeparator(arg.type, Boolean(arg.defaultValue)), this.argTypeRepresentation(arg.type)]
   }
 
   argSeparator(type: GraphQLInputType, hasDefaultValue: boolean) {
-    if (hasDefaultValue || isNullableType(type)) {
-      return '?:'
+    if (hasDefaultValue || isNonNullType(type)) {
+      return ':'
     }
 
-    return ':'
+    return '?:'
   }
 
   argTypeRepresentation(arg: GraphQLInputType): string {

--- a/tests/__snapshots__/typegenPrinter.spec.ts.snap
+++ b/tests/__snapshots__/typegenPrinter.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`typegenPrinter builds the input object type defs 1`] = `
   }
   PostFilters: { // input type
     order: NexusGenEnums['OrderEnum']; // OrderEnum!
-    search?: string | null; // String
+    search: string | null; // String
   }
 }"
 `;
@@ -167,7 +167,7 @@ export interface NexusGenInputs {
   }
   PostFilters: { // input type
     order: NexusGenEnums['OrderEnum']; // OrderEnum!
-    search?: string | null; // String
+    search: string | null; // String
   }
 }
 

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -279,7 +279,7 @@ export interface NexusGenArgTypes {
     user: {
       // args
       id?: string | null // ID
-      status?: NexusGenEnums['UserStatus'] | null // UserStatus
+      status: NexusGenEnums['UserStatus'] | null // UserStatus
     }
   }
   User: {

--- a/tests/typegen/types.gen.ts
+++ b/tests/typegen/types.gen.ts
@@ -16,7 +16,7 @@ export interface NexusGenInputs {
   PostFilters: {
     // input type
     order: NexusGenEnums['OrderEnum'] // OrderEnum!
-    search?: string | null // String
+    search: string | null // String
   }
 }
 


### PR DESCRIPTION
Reverts graphql-nexus/nexus#965

See comment in: https://github.com/graphql-nexus/nexus/issues/921#issuecomment-892998307

Need to check this again & think through the intended behavior, since I believe these types are primarily used for the `args` provided to a resolver, and if a default value is supplied it should exist on the args.