### PR TITLE
fix: printer imports, follow up from #967

### DIFF
--- a/src/makeSchema.ts
+++ b/src/makeSchema.ts
@@ -20,10 +20,17 @@ export function makeSchema(config: SchemaConfig): NexusGraphQLSchema {
     // in the optional thunk for the typegen config
     const typegenPromise = new TypegenMetadata(typegenConfig).generateArtifacts(schema)
     if (config.shouldExitAfterGenerateArtifacts) {
+      let typegenPath = '(not enabled)'
+      if (typegenConfig.outputs.typegen) {
+        typegenPath = typegenConfig.outputs.typegen.outputPath
+        if (typegenConfig.outputs.typegen.globalsPath) {
+          typegenPath += ` / ${typegenConfig.outputs.typegen.globalsPath}`
+        }
+      }
       typegenPromise
         .then(() => {
           console.log(`Generated Artifacts:
-          TypeScript Types  ==> ${typegenConfig.outputs.typegen || '(not enabled)'}
+          TypeScript Types  ==> ${typegenPath}
           GraphQL Schema    ==> ${typegenConfig.outputs.schema || '(not enabled)'}`)
           process.exit(0)
         })

--- a/src/typegenMetadata.ts
+++ b/src/typegenMetadata.ts
@@ -13,7 +13,7 @@ export interface TypegenMetadataConfig
   nexusSchemaImportId?: string
   outputs: {
     schema: null | string
-    typegen: null | string | ConfiguredTypegen
+    typegen: null | ConfiguredTypegen
   }
 }
 
@@ -162,7 +162,7 @@ export class TypegenMetadata {
     if (this.config.sourceTypes) {
       return typegenAutoConfig(this.config.sourceTypes, this.config.contextType)(
         schema,
-        typegenPath || this.normalizeTypegenPath(this.config.outputs.typegen) || ''
+        typegenPath || this.config.outputs.typegen?.outputPath || ''
       )
     }
 
@@ -173,9 +173,5 @@ export class TypegenMetadata {
       contextTypeImport: this.config.contextType,
       sourceTypeMap: {},
     }
-  }
-
-  private normalizeTypegenPath(typegen: string | ConfiguredTypegen | null) {
-    return typeof typegen === 'string' ? typegen : typegen ? typegen.outputPath : null
   }
 }

--- a/src/typegenMetadata.ts
+++ b/src/typegenMetadata.ts
@@ -140,13 +140,14 @@ export class TypegenMetadata {
 
   /** Generates the type definitions */
   async generateConfiguredTypes(schema: NexusGraphQLSchema, typegen: ConfiguredTypegen) {
-    const { outputPath: typegenPath, globalsPath, declareInputs = true } = typegen
+    const { outputPath: typegenPath, globalsPath, globalsHeaders, declareInputs = true } = typegen
     const typegenInfo = await this.getTypegenInfo(schema, typegenPath)
 
     return new TypegenPrinter(schema, {
       ...typegenInfo,
       typegenPath,
       globalsPath,
+      globalsHeaders,
       declareInputs,
     }).printConfigured()
   }

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -55,7 +55,7 @@ type RootTypeMapping = Record<string, string | Record<string, [string, string]>>
 interface TypegenInfoWithFile extends TypegenInfo {
   typegenPath: string
   globalsPath?: string
-  globalsHeaders?: string
+  globalsHeaders?: string[]
   declareInputs?: boolean
 }
 
@@ -162,7 +162,8 @@ export class TypegenPrinter {
           this.typegenInfo.globalsPath ?? ''
         )}'`
       )
-      headers.unshift(this.typegenInfo.globalsHeaders ?? TYPEGEN_HEADER)
+      headers.unshift(...(this.typegenInfo.globalsHeaders ?? []))
+      headers.unshift(TYPEGEN_HEADER)
     }
 
     return headers.join('\n')

--- a/src/typegenUtils.ts
+++ b/src/typegenUtils.ts
@@ -14,7 +14,7 @@ export function resolveTypegenConfig(config: BuilderConfigInput): TypegenMetadat
 
   const defaultSDLFilePath = path.join(process.cwd(), 'schema.graphql')
 
-  let typegenFilePath: string | ConfiguredTypegen | null = null
+  let typegenFilePath: ConfiguredTypegen | null = null
   let sdlFilePath: string | null = null
 
   if (outputs === undefined) {
@@ -32,7 +32,9 @@ export function resolveTypegenConfig(config: BuilderConfigInput): TypegenMetadat
     }
     // handle typegen configuration
     if (typeof outputs.typegen === 'string') {
-      typegenFilePath = assertAbsolutePath(outputs.typegen, 'outputs.typegen')
+      typegenFilePath = {
+        outputPath: assertAbsolutePath(outputs.typegen, 'outputs.typegen'),
+      }
     } else if (typeof outputs.typegen === 'object') {
       typegenFilePath = {
         ...outputs.typegen,

--- a/tests/__snapshots__/typegenPrinterGlobals.spec.ts.snap
+++ b/tests/__snapshots__/typegenPrinterGlobals.spec.ts.snap
@@ -16,7 +16,7 @@ declare global {
   interface NexusGen extends NexusGenTypes {}
 }
 
-import type { TestContext } from \\"./../__helpers/index\\"
+
 
 
 declare global {

--- a/tests/backingTypes.spec.ts
+++ b/tests/backingTypes.spec.ts
@@ -49,7 +49,9 @@ describe('sourceTypes', () => {
   beforeEach(async () => {
     metadata = new TypegenMetadata({
       outputs: {
-        typegen: path.join(__dirname, 'test-gen.ts'),
+        typegen: {
+          outputPath: path.join(__dirname, 'test-gen.ts'),
+        },
         schema: path.join(__dirname, 'test-gen.graphql'),
       },
       sourceTypes: {

--- a/tests/typegenPrinter.spec.ts
+++ b/tests/typegenPrinter.spec.ts
@@ -35,7 +35,9 @@ describe('typegenPrinter', () => {
 
     metadata = new TypegenMetadata({
       outputs: {
-        typegen: path.join(__dirname, 'test-gen.ts'),
+        typegen: {
+          outputPath: path.join(__dirname, 'test-gen.ts'),
+        },
         schema: path.join(__dirname, 'test-gen.graphql'),
       },
       sourceTypes: {


### PR DESCRIPTION
Ensure that unused imports are not printed when splitting global & types files.