### PR TITLE
fix: revert typegen.declareInputs default to false

### DIFF
--- a/examples/kitchen-sink/src/index.ts
+++ b/examples/kitchen-sink/src/index.ts
@@ -24,6 +24,7 @@ const schema = makeSchema({
     typegen: {
       outputPath: path.join(__dirname, './kitchen-sink.gen.ts'),
       globalsPath: path.join(__dirname, './kitchen-sink-globals.gen.ts'),
+      declareInputs: true,
     },
   },
   plugins: [

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -192,7 +192,7 @@ export interface ConfiguredTypegen {
   /**
    * If "true", declares dedicated interfaces for any inputs / args
    *
-   * @default true
+   * @default false
    */
   declareInputs?: boolean
 }

--- a/src/typegenMetadata.ts
+++ b/src/typegenMetadata.ts
@@ -132,7 +132,7 @@ export class TypegenMetadata {
     const typegenInfo = await this.getTypegenInfo(schema, typegenPath)
 
     return new TypegenPrinter(schema, {
-      declareInputs: true,
+      declareInputs: false,
       ...typegenInfo,
       typegenPath,
     }).print()
@@ -140,7 +140,7 @@ export class TypegenMetadata {
 
   /** Generates the type definitions */
   async generateConfiguredTypes(schema: NexusGraphQLSchema, typegen: ConfiguredTypegen) {
-    const { outputPath: typegenPath, globalsPath, globalsHeaders, declareInputs = true } = typegen
+    const { outputPath: typegenPath, globalsPath, globalsHeaders, declareInputs = false } = typegen
     const typegenInfo = await this.getTypegenInfo(schema, typegenPath)
 
     return new TypegenPrinter(schema, {

--- a/tests/__snapshots__/typegenPrinterGlobals.spec.ts.snap
+++ b/tests/__snapshots__/typegenPrinterGlobals.spec.ts.snap
@@ -267,29 +267,21 @@ exports[`typegenPrinter: no input changes should print the full output, with inp
 
 import type { core } from \\"nexus\\"
 
-export interface CreatePostInput {
-  name: string; // String!
-  author: string; // ID!
-  geo: Array<Array<number | null>>; // [[Float]!]!
-}
-
-export interface PostFilters {
-  order: OrderEnum; // OrderEnum!
-  search: string | null; // String
-}
-
 export interface NexusGenInputs {
-  CreatePostInput: CreatePostInput
-  PostFilters: PostFilters
+  CreatePostInput: { // input type
+    name: string; // String!
+    author: string; // ID!
+    geo: Array<Array<number | null>>; // [[Float]!]!
+  }
+  PostFilters: { // input type
+    order: NexusGenEnums['OrderEnum']; // OrderEnum!
+    search: string | null; // String
+  }
 }
-
-export type OrderEnum = \\"ASC\\" | \\"DESC\\"
-
-export type SomeEnum = \\"A\\" | \\"B\\"
 
 export interface NexusGenEnums {
-  OrderEnum: OrderEnum
-  SomeEnum: SomeEnum
+  OrderEnum: \\"ASC\\" | \\"DESC\\"
+  SomeEnum: \\"A\\" | \\"B\\"
 }
 
 export interface NexusGenScalars {
@@ -344,7 +336,7 @@ export interface NexusGenFieldTypes {
     email: string; // String!
     phone: string | null; // String
     posts: NexusGenRootTypes['Post'][]; // [Post!]!
-    outEnum: SomeEnum | null; // SomeEnum
+    outEnum: NexusGenEnums['SomeEnum'] | null; // SomeEnum
   }
   Node: { // field return type
     id: string; // ID!
@@ -382,42 +374,30 @@ export interface NexusGenFieldTypeNames {
   }
 }
 
-export interface MutationSomeListArgs {
-  items: Array<string | null>; // [String]!
-}
-
-export interface MutationCreatePostArgs {
-  input: CreatePostInput; // CreatePostInput!
-}
-
-export interface MutationRegisterClickArgs {
-  uuid?: NexusGenScalars['UUID'] | null; // UUID
-}
-
-export interface QueryPostsArgs {
-  filters: PostFilters; // PostFilters!
-}
-
-export interface UserNameArgs {
-  prefix?: string | null; // String
-}
-
-export interface UserPostsArgs {
-  filters?: PostFilters | null; // PostFilters
-}
-
 export interface NexusGenArgTypes {
   Mutation: {
-    someList: MutationSomeListArgs
-    createPost: MutationCreatePostArgs
-    registerClick: MutationRegisterClickArgs
+    someList: { // args
+      items: Array<string | null>; // [String]!
+    }
+    createPost: { // args
+      input: NexusGenInputs['CreatePostInput']; // CreatePostInput!
+    }
+    registerClick: { // args
+      uuid?: NexusGenScalars['UUID'] | null; // UUID
+    }
   }
   Query: {
-    posts: QueryPostsArgs
+    posts: { // args
+      filters: NexusGenInputs['PostFilters']; // PostFilters!
+    }
   }
   User: {
-    name: UserNameArgs
-    posts: UserPostsArgs
+    name: { // args
+      prefix?: string | null; // String
+    }
+    posts: { // args
+      filters?: NexusGenInputs['PostFilters'] | null; // PostFilters
+    }
   }
 }
 

--- a/tests/integrations/declarativeWrappingPlugin/__typegen.ts
+++ b/tests/integrations/declarativeWrappingPlugin/__typegen.ts
@@ -4,12 +4,11 @@ declare global {
   interface NexusGen extends NexusGenTypes {}
 }
 
-export interface InlineInputType {
-  abc: number // Int!
-}
-
 export interface NexusGenInputs {
-  InlineInputType: InlineInputType
+  InlineInputType: {
+    // input type
+    abc: number // Int!
+  }
 }
 
 export interface NexusGenEnums {}
@@ -63,18 +62,16 @@ export interface NexusGenFieldTypeNames {
   }
 }
 
-export interface DeclarativeWrappingOutputSomeListOfListsArgs {
-  int: number // Int!
-}
-
-export interface DeclarativeWrappingOutputSomeNullFieldArgs {
-  input?: InlineInputType | null // InlineInputType
-}
-
 export interface NexusGenArgTypes {
   DeclarativeWrappingOutput: {
-    someListOfLists: DeclarativeWrappingOutputSomeListOfListsArgs
-    someNullField: DeclarativeWrappingOutputSomeNullFieldArgs
+    someListOfLists: {
+      // args
+      int: number // Int!
+    }
+    someNullField: {
+      // args
+      input?: NexusGenInputs['InlineInputType'] | null // InlineInputType
+    }
   }
 }
 

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -45,24 +45,20 @@ declare global {
   interface NexusGen extends NexusGenTypes {}
 }
 
-export interface PostSearchInput {
-  body?: string | null // String
-  title?: string | null // String
-}
-
-export interface Something {
-  id: number // Int!
-}
-
 export interface NexusGenInputs {
-  PostSearchInput: PostSearchInput
-  Something: Something
+  PostSearchInput: {
+    // input type
+    body?: string | null // String
+    title?: string | null // String
+  }
+  Something: {
+    // input type
+    id: number // Int!
+  }
 }
-
-export type UserStatus = 'active' | 'pending'
 
 export interface NexusGenEnums {
-  UserStatus: UserStatus
+  UserStatus: 'active' | 'pending'
 }
 
 export interface NexusGenScalars {
@@ -261,44 +257,39 @@ export interface NexusGenFieldTypeNames {
   }
 }
 
-export interface MutationCreateUserArgs {
-  firstName?: string | null // String
-  lastName?: string | null // String
-}
-
-export interface PostEdgeDeltaArgs {
-  format?: string | null // String
-}
-
-export interface QuerySearchPostsArgs {
-  input?: PostSearchInput | null // PostSearchInput
-}
-
-export interface QueryUserArgs {
-  id?: string | null // ID
-  status: UserStatus | null // UserStatus
-}
-
-export interface UserPostsArgs {
-  after?: string | null // String
-  before?: string | null // String
-  first?: number | null // Int
-  last?: number | null // Int
-}
-
 export interface NexusGenArgTypes {
   Mutation: {
-    createUser: MutationCreateUserArgs
+    createUser: {
+      // args
+      firstName?: string | null // String
+      lastName?: string | null // String
+    }
   }
   PostEdge: {
-    delta: PostEdgeDeltaArgs
+    delta: {
+      // args
+      format?: string | null // String
+    }
   }
   Query: {
-    searchPosts: QuerySearchPostsArgs
-    user: QueryUserArgs
+    searchPosts: {
+      // args
+      input?: NexusGenInputs['PostSearchInput'] | null // PostSearchInput
+    }
+    user: {
+      // args
+      id?: string | null // ID
+      status: NexusGenEnums['UserStatus'] | null // UserStatus
+    }
   }
   User: {
-    posts: UserPostsArgs
+    posts: {
+      // args
+      after?: string | null // String
+      before?: string | null // String
+      first?: number | null // Int
+      last?: number | null // Int
+    }
   }
 }
 

--- a/tests/typegen/types.gen.ts
+++ b/tests/typegen/types.gen.ts
@@ -6,29 +6,23 @@ declare global {
   interface NexusGen extends NexusGenTypes {}
 }
 
-export interface CreatePostInput {
-  author: string // ID!
-  geo: Array<Array<number | null>> // [[Float]!]!
-  name: string // String!
-}
-
-export interface PostFilters {
-  order: OrderEnum // OrderEnum!
-  search: string | null // String
-}
-
 export interface NexusGenInputs {
-  CreatePostInput: CreatePostInput
-  PostFilters: PostFilters
+  CreatePostInput: {
+    // input type
+    author: string // ID!
+    geo: Array<Array<number | null>> // [[Float]!]!
+    name: string // String!
+  }
+  PostFilters: {
+    // input type
+    order: NexusGenEnums['OrderEnum'] // OrderEnum!
+    search: string | null // String
+  }
 }
-
-export type OrderEnum = 'ASC' | 'DESC'
-
-export type SomeEnum = 'A' | 'B'
 
 export interface NexusGenEnums {
-  OrderEnum: OrderEnum
-  SomeEnum: SomeEnum
+  OrderEnum: 'ASC' | 'DESC'
+  SomeEnum: 'A' | 'B'
 }
 
 export interface NexusGenScalars {
@@ -85,7 +79,7 @@ export interface NexusGenFieldTypes {
     email: string // String!
     id: string // ID!
     name: string // String!
-    outEnum: SomeEnum | null // SomeEnum
+    outEnum: NexusGenEnums['SomeEnum'] | null // SomeEnum
     phone: string | null // String
     posts: NexusGenRootTypes['Post'][] // [Post!]!
   }
@@ -131,42 +125,36 @@ export interface NexusGenFieldTypeNames {
   }
 }
 
-export interface MutationCreatePostArgs {
-  input: CreatePostInput // CreatePostInput!
-}
-
-export interface MutationRegisterClickArgs {
-  uuid?: NexusGenScalars['UUID'] | null // UUID
-}
-
-export interface MutationSomeListArgs {
-  items: Array<string | null> // [String]!
-}
-
-export interface QueryPostsArgs {
-  filters: PostFilters // PostFilters!
-}
-
-export interface UserNameArgs {
-  prefix?: string | null // String
-}
-
-export interface UserPostsArgs {
-  filters?: PostFilters | null // PostFilters
-}
-
 export interface NexusGenArgTypes {
   Mutation: {
-    createPost: MutationCreatePostArgs
-    registerClick: MutationRegisterClickArgs
-    someList: MutationSomeListArgs
+    createPost: {
+      // args
+      input: NexusGenInputs['CreatePostInput'] // CreatePostInput!
+    }
+    registerClick: {
+      // args
+      uuid?: NexusGenScalars['UUID'] | null // UUID
+    }
+    someList: {
+      // args
+      items: Array<string | null> // [String]!
+    }
   }
   Query: {
-    posts: QueryPostsArgs
+    posts: {
+      // args
+      filters: NexusGenInputs['PostFilters'] // PostFilters!
+    }
   }
   User: {
-    name: UserNameArgs
-    posts: UserPostsArgs
+    name: {
+      // args
+      prefix?: string | null // String
+    }
+    posts: {
+      // args
+      filters?: NexusGenInputs['PostFilters'] | null // PostFilters
+    }
   }
 }
 


### PR DESCRIPTION
Continuing to iterate on changes from #967 

The current new behavior would technically be a breaking change if it's defaulted to `true`, since it'd export more types which could conflict with existing types if you're doing `export *` from the typegen file. Also have plans to refine the typegen a bit more before it ships.