### PR TITLE
feat: ability to rename root types

### DIFF
--- a/tests/__snapshots__/builder.spec.ts.snap
+++ b/tests/__snapshots__/builder.spec.ts.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`builder can replace the Mutation root type with an alternate type 1`] = `
+"schema {
+  query: Query
+  mutation: RootMutation
+}
+
+type RootMutation {
+  name: String
+}
+
+type Mutation {
+  ok: String
+}
+
+type Query {
+  ok: Boolean!
+}
+"
+`;
+
+exports[`builder can replace the Query root type with an alternate type 1`] = `
+"schema {
+  query: RootQuery
+}
+
+type RootQuery {
+  name: String
+}
+
+type Query {
+  ok: String
+}
+"
+`;
+
+exports[`builder can replace the Subscription root type with an alternate type 1`] = `
+"schema {
+  query: Query
+  subscription: RootSubscription
+}
+
+type RootSubscription {
+  name: String
+}
+
+type Subscription {
+  ok: String
+}
+
+type Query {
+  ok: Boolean!
+}
+"
+`;

--- a/tests/__snapshots__/builder.spec.ts.snap
+++ b/tests/__snapshots__/builder.spec.ts.snap
@@ -6,16 +6,16 @@ exports[`builder can replace the Mutation root type with an alternate type 1`] =
   mutation: RootMutation
 }
 
-type RootMutation {
-  name: String
-}
-
 type Mutation {
   ok: String
 }
 
 type Query {
   ok: Boolean!
+}
+
+type RootMutation {
+  name: String
 }
 "
 `;
@@ -25,12 +25,12 @@ exports[`builder can replace the Query root type with an alternate type 1`] = `
   query: RootQuery
 }
 
-type RootQuery {
-  name: String
-}
-
 type Query {
   ok: String
+}
+
+type RootQuery {
+  name: String
 }
 "
 `;
@@ -41,16 +41,16 @@ exports[`builder can replace the Subscription root type with an alternate type 1
   subscription: RootSubscription
 }
 
+type Query {
+  ok: Boolean!
+}
+
 type RootSubscription {
   name: String
 }
 
 type Subscription {
   ok: String
-}
-
-type Query {
-  ok: Boolean!
 }
 "
 `;

--- a/tests/builder.spec.ts
+++ b/tests/builder.spec.ts
@@ -1,4 +1,4 @@
-import { printSchema } from 'graphql'
+import { lexicographicSortSchema, printSchema } from 'graphql'
 import { makeSchema, objectType } from '../src'
 
 describe('builder', () => {
@@ -23,7 +23,7 @@ describe('builder', () => {
         query: OtherQuery,
       },
     })
-    expect(printSchema(schema)).toMatchSnapshot()
+    expect(printSchema(lexicographicSortSchema(schema))).toMatchSnapshot()
   })
 
   it('can replace the Mutation root type with an alternate type', () => {
@@ -47,7 +47,7 @@ describe('builder', () => {
         mutation: OtherMutation,
       },
     })
-    expect(printSchema(schema)).toMatchSnapshot()
+    expect(printSchema(lexicographicSortSchema(schema))).toMatchSnapshot()
   })
 
   it('can replace the Subscription root type with an alternate type', () => {
@@ -71,6 +71,6 @@ describe('builder', () => {
         subscription: OtherSubscription,
       },
     })
-    expect(printSchema(schema)).toMatchSnapshot()
+    expect(printSchema(lexicographicSortSchema(schema))).toMatchSnapshot()
   })
 })

--- a/tests/builder.spec.ts
+++ b/tests/builder.spec.ts
@@ -1,0 +1,76 @@
+import { printSchema } from 'graphql'
+import { makeSchema, objectType } from '../src'
+
+describe('builder', () => {
+  it('can replace the Query root type with an alternate type', () => {
+    const OtherQuery = objectType({
+      name: 'RootQuery',
+      definition(t) {
+        t.string('name')
+      },
+    })
+
+    const Query = objectType({
+      name: 'Query',
+      definition(t) {
+        t.string('ok')
+      },
+    })
+
+    const schema = makeSchema({
+      types: [OtherQuery, Query],
+      schemaRoots: {
+        query: OtherQuery,
+      },
+    })
+    expect(printSchema(schema)).toMatchSnapshot()
+  })
+
+  it('can replace the Mutation root type with an alternate type', () => {
+    const OtherMutation = objectType({
+      name: 'RootMutation',
+      definition(t) {
+        t.string('name')
+      },
+    })
+
+    const Mutation = objectType({
+      name: 'Mutation',
+      definition(t) {
+        t.string('ok')
+      },
+    })
+
+    const schema = makeSchema({
+      types: [OtherMutation, Mutation],
+      schemaRoots: {
+        mutation: OtherMutation,
+      },
+    })
+    expect(printSchema(schema)).toMatchSnapshot()
+  })
+
+  it('can replace the Subscription root type with an alternate type', () => {
+    const OtherSubscription = objectType({
+      name: 'RootSubscription',
+      definition(t) {
+        t.string('name')
+      },
+    })
+
+    const Subscription = objectType({
+      name: 'Subscription',
+      definition(t) {
+        t.string('ok')
+      },
+    })
+
+    const schema = makeSchema({
+      types: [OtherSubscription, Subscription],
+      schemaRoots: {
+        subscription: OtherSubscription,
+      },
+    })
+    expect(printSchema(schema)).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Adds `config. schemaRoots` to `makeSchema`, providing the ability to configure the root `query` / `mutation` / `subcription` schema types.

Closes #867