### PR TITLE
docs: change all "npm add" to "npm install"

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/02-chapter-1-setup-and-first-query.mdx
+++ b/docs/content/010-getting-started/03-tutorial/02-chapter-1-setup-and-first-query.mdx
@@ -18,7 +18,7 @@ Start by creating your project directory, initializing your `package.json`, and 
 ```bash-symbol copy
 mkdir nexus-tutorial && cd nexus-tutorial
 npm init -y
-npm add nexus graphql apollo-server
+npm install nexus graphql apollo-server
 ```
 
 > Note: `nexus` works with any GraphQL compliant server. We'll use `apollo-server` in this tutorial, but you're free to use whichever fits your use-case best.
@@ -26,7 +26,7 @@ npm add nexus graphql apollo-server
 We'll also need `typescript` and `ts-node-dev` as dev dependencies. `ts-node-dev` will enable you to transpile your TS files on the fly and restart your API on changes.
 
 ```bash-symbol copy
-npm add --save-dev typescript ts-node-dev
+npm install --save-dev typescript ts-node-dev
 ```
 
 To properly get full advantage of TypeScript, we'll need a `tsconfig.json` file. Create one at the root of your project and copy paste the following

--- a/docs/content/010-getting-started/03-tutorial/05-chapter-4-testing-your-api.mdx
+++ b/docs/content/010-getting-started/03-tutorial/05-chapter-4-testing-your-api.mdx
@@ -25,7 +25,7 @@ During this tutorial, you'll use the [Jest testing framework](https://jestjs.io/
 First, install `jest` and accompanying tools.
 
 ```bash-symbol copy
-npm add --save-dev jest @types/jest ts-jest graphql-request get-port
+npm install --save-dev jest @types/jest ts-jest graphql-request get-port
 ```
 
 Then, configure jest and npm scripts in your `package.json`

--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -35,8 +35,8 @@ Now that you know a bit about Prisma, let's get going! Do the following:
 like so:
 
 ```bash-symbol copy
-npm add @prisma/client
-npm add --save-dev prisma
+npm install @prisma/client
+npm install --save-dev prisma
 ```
 
 Next, add Prisma to your project by creating your [Prisma schema](https://www.prisma.io/docs/concepts/components/prisma-schema/) file with the following command:

--- a/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/07-chapter-6-testing-with-prisma.mdx
@@ -26,7 +26,7 @@ To achieve some of the steps described above, we'll tweak our test context.
 First, install the `sqlite3` and `nanoid` packages
 
 ```bash copy
-npm add --save-dev sqlite3 @types/sqlite3
+npm install --save-dev sqlite3 @types/sqlite3
 ```
 
 Then, head to your `tests/__helpers.ts` file to add the following imports and code

--- a/docs/content/030-plugins/050-prisma/010-overview.mdx
+++ b/docs/content/030-plugins/050-prisma/010-overview.mdx
@@ -11,8 +11,8 @@ This plugin integrates [Prisma](https://www.prisma.io/) into [Nexus](https://nex
 ## Installation
 
 ```bash-symbol
-npm add nexus-plugin-prisma @prisma/client
-npm add -D prisma
+npm install nexus-plugin-prisma @prisma/client
+npm install -D prisma
 ```
 
 ## Usage

--- a/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
+++ b/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
@@ -27,7 +27,7 @@ You will need to manage the TypeScript toolchain yourself.
 1. Install `typescript`, `ts-node`, and `ts-node-dev`.
 
    ```bash-symbol
-   npm add -D typescript ts-node ts-node-dev
+   npm install -D typescript ts-node ts-node-dev
    ```
 
 2. The following applies to VSCode but something like it might apply to other editors as well. You must also make sure your editor is set to use the local version of TypeScript rather than the one the editor ships with. Summon the command pallet `command+shift+p` and then enter and select `typescript: select TypeScript Version...`. Then select `Workspace Version`.
@@ -205,13 +205,13 @@ Nexus framework comes bundled with Apollo Server and runs it for you. You will n
 1. Install new dependencies
 
    ```tsx
-   npm add express apollo-server-express
+   npm install express apollo-server-express
    ```
 
 2. If using TypeScript then Install typings for Express
 
    ```tsx
-   npm add -D @types/express
+   npm install -D @types/express
    ```
 
 3. If using TypeScript then you [need to](https://github.com/apollographql/apollo-server/issues/1977#issuecomment-662946590) enable `esModuleInterop` to be able to use Apollo Server
@@ -337,7 +337,7 @@ Nexus Framework has some builtin logging functionality. You can approximate it a
 1. Install your logger
 
    ```tsx
-   npm add floggy
+   npm install floggy
    ```
 
 2. Create your application logger. The logger you export here should be used across your codebase.
@@ -386,7 +386,7 @@ You need to explicitly setup all custom scalars yourself. To match what Nexus Fr
 1. Install the `graphql-scalars` package
 
    ```json
-   npm add graphql-scalars
+   npm install graphql-scalars
    ```
 
 2. Setup the `Json` and `DateTime` scalars
@@ -536,13 +536,13 @@ In Nexus Framework there was a testing module for system testing your app. You n
 1.  Install your test framework
 
     ```tsx
-    npm add jest
+    npm install jest
     ```
 
 2.  If you are a TypeScript user then install and configure `ts-jest`
 
     ```bash
-    npm add ts-jest
+    npm install ts-jest
     ```
 
     We will configure using a `jest.config.js` module in your project root. Do not use a JSON based configuration unless you know that you won't need the dynamic code used in some later steps here.
@@ -639,7 +639,7 @@ In Nexus Framework there was a testing module for system testing your app. You n
 6.  You will need a way to run your app in tests. Here is one way [adapted from the tutorial](https://todo.com).
 
     ```tsx
-    npm add -D graphql-request
+    npm install -D graphql-request
     ```
 
     ```tsx
@@ -688,7 +688,7 @@ Nexus Framework had a CLI for scaffolding new projects. You can approximate this
 Nexus Framework has a gradual settings API with features such as automatic mapping of environment variables to settings. You can use the [`setset`](https://github.com/jasonkuhrt/setset) package manually to gain back this functionality.
 
 ```tsx
-npm add setset
+npm install setset
 ```
 
 ```tsx

--- a/docs/content/040-adoption-guides/030-neuxs-framework-prisma-users.mdx
+++ b/docs/content/040-adoption-guides/030-neuxs-framework-prisma-users.mdx
@@ -13,8 +13,8 @@ If you're looking to migrate from the Nexus Framework over to Nexus and you're u
 You will need to install the Prisma dependencies yourself now.
 
 ```
-npm add -D @prisma/cli
-npm add @prisma/client
+npm install -D @prisma/cli
+npm install @prisma/client
 ```
 
 You must also make sure that you are using the version `0.20` or later of `nexus-plugin-prisma`.

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -22,8 +22,8 @@ Check out the [example projects](https://github.com/graphql-nexus/nexus/tree/mai
 ## Installation
 
 ```sh
-npm add nexus
-npm add graphql # required as a peer dependency
+npm install nexus
+npm install graphql # required as a peer dependency
 ```
 
 If you are using TypeScript version `4.1` is suggested. Nexus doesn't have a hard requirement for it yet but may in a future non-breaking release.


### PR DESCRIPTION
Noticed the npm add command while reading the docs and I thought maybe it was a little confusion with yarn add. So I wanted to help change it back to npm install.