### PR TITLE
Added missing type in getting started example

### DIFF
--- a/docs/content/010-getting-started/04-why-nexus.mdx
+++ b/docs/content/010-getting-started/04-why-nexus.mdx
@@ -63,6 +63,7 @@ const Post = objectType({
 const Query = queryType({
   definition(t) {
     t.list.field('posts', {
+      type: Post,
       resolve: () => [
         {
           id: '1',


### PR DESCRIPTION
queryType is missing type field. TypeScript would throw error and not compile.