### PR TITLE
chore(docs): readme update -- fix code sample to include ".ts" in module path

### DIFF
--- a/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
+++ b/docs/content/040-adoption-guides/020-nexus-framework-users.mdx
@@ -448,7 +448,7 @@ import * as Path from 'path'
 
 Nexus.makeSchema({
   contextType: {
-    module: Path.join(__dirname, './path/to/contextModule'),
+    module: Path.join(__dirname, './path/to/contextModule.ts'),
     alias: 'ContextModule',
     export: 'Context'
   },


### PR DESCRIPTION
The sample code in the Context API Type Discovery section has a missing piece
was getting
```
Error: Root typing path "/Users/.../my-project/api/contextModule" for the type "context" does not exist
```

Just needed to add ".ts" to the path 