### PR TITLE
Fixed typos

### DIFF
--- a/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
+++ b/docs/content/010-getting-started/03-tutorial/06-chapter-5-persisting-data-via-prisma.mdx
@@ -266,15 +266,15 @@ export const PostMutation = extendType({
         draftId: nonNull(intArg()),
       },
       resolve(_root, args, ctx) {
--       let postToPublish = ctx.db.posts.find((p) => p.id === args.draftId)
+-       let draftToPublish = ctx.db.posts.find((p) => p.id === args.draftId)
 
--       if (!postToPublish) {
+-       if (!draftToPublish) {
 -         throw new Error('Could not find draft with id ' + args.draftId)
 -       }
 
--       postToPublish.published = true
+-       draftToPublish.published = true
 
--       return postToPublish
+-       return draftToPublish
 
 +       return ctx.db.post.update({
 +         where: { id: args.draftId },


### PR DESCRIPTION
Fixed the typos where `draftToPublish` (used in the previous example) were mistakenly written as `postToPublish` which might lead to confusion for some readers.