### PR TITLE
docs: Update comment for `shouldGenerateArtifacts`

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -278,7 +278,7 @@ export interface BuilderConfigInput {
       }
   /**
    * Whether the schema & types are generated when the server starts. Default is !process.env.NODE_ENV ||
-   * process.env.NODE_ENV === "development"
+   * process.env.NODE_ENV !== "production"
    */
   shouldGenerateArtifacts?: boolean
   /** Register the Source Types */


### PR DESCRIPTION
Update comment to reflect the current behavior as per [`src/typegenUtils.ts`](https://github.com/graphql-nexus/nexus/blob/bc12ca0f8e704de0b7e911fa6352e8f2bb48cb22/src/typegenUtils.ts#L11). Ideally this behavior would be updated to reflect the original comment as most use cases won't need artifacts generated outside of `development`, but that would introduce a breaking change so probably needs to wait for a major release.