### PR TITLE
fix: specify GraphQLFieldResolver type to ensure graphql v15 compatibility

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -176,7 +176,7 @@ export type MiddlewareFn = (
 export function composeMiddlewareFns<T>(
   middlewareFns: MiddlewareFn[],
   resolver: GraphQLFieldResolver<any, any>
-) {
+): GraphQLFieldResolver<any, any> {
   let lastResolver = resolver
   for (const middleware of middlewareFns.reverse()) {
     const currentNext = middleware


### PR DESCRIPTION
If this type is not specified the generated definition file (plugin.d.ts) includes the four generic types, which makes it incompatible with graphql v15.

Fixes #1073