### PR TITLE
chore: change facebook.github.io to relay.dev links

### DIFF
--- a/docs/content/030-plugins/01-connection.mdx
+++ b/docs/content/030-plugins/01-connection.mdx
@@ -4,7 +4,7 @@ title: Relay Connection
 
 ## Connection Plugin
 
-The connection plugin provides a new method on the object definition builder, enabling paginated associations between types, following the [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm#sec-Node). It provides simple ways to customize fields available on the `Connection`, `Edges`, or `PageInfo` types.
+The connection plugin provides a new method on the object definition builder, enabling paginated associations between types, following the [Relay Connection Specification](https://relay.dev/graphql/connections.htm#sec-Node). It provides simple ways to customize fields available on the `Connection`, `Edges`, or `PageInfo` types.
 
 To install, add the `connectionPlugin` to the `makeSchema.plugins` array, along with any other plugins
 you'd like to include:

--- a/examples/kitchen-sink/kitchen-sink-schema.graphql
+++ b/examples/kitchen-sink/kitchen-sink-schema.graphql
@@ -19,24 +19,24 @@ interface Baz {
 
 type BooleanConnection {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   """
   edges: [BooleanEdge]
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   """
   pageInfo: PageInfo!
 }
 
 type BooleanEdge {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor
+  https://relay.dev/graphql/connections.htm#sec-Cursor
   """
   cursor: String!
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Node
+  https://relay.dev/graphql/connections.htm#sec-Node
   """
   node: Boolean
 }
@@ -49,24 +49,24 @@ scalar Date
 
 type DateConnection {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   """
   edges: [DateEdge]
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   """
   pageInfo: PageInfo!
 }
 
 type DateEdge {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor
+  https://relay.dev/graphql/connections.htm#sec-Cursor
   """
   cursor: String!
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Node
+  https://relay.dev/graphql/connections.htm#sec-Node
   """
   node: Date
 }
@@ -104,7 +104,7 @@ interface Node {
 }
 
 """
-PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
 """
 type PageInfo {
   """
@@ -306,24 +306,24 @@ type User {
 
 type UserConnection {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   """
   edges: [UserEdge]
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   """
   pageInfo: PageInfo!
 }
 
 type UserEdge {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor
+  https://relay.dev/graphql/connections.htm#sec-Cursor
   """
   cursor: String!
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Node
+  https://relay.dev/graphql/connections.htm#sec-Node
   """
   node: User
 }

--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -494,11 +494,11 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                   definition(t2) {
                     t2.list.field('edges', {
                       type: edgeName as any,
-                      description: `https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types`,
+                      description: `https://relay.dev/graphql/connections.htm#sec-Edge-Types`,
                     })
                     t2.nonNull.field('pageInfo', {
                       type: 'PageInfo' as any,
-                      description: `https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo`,
+                      description: `https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo`,
                     })
                     if (includeNodesField) {
                       t2.list.field('nodes', {
@@ -530,11 +530,11 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                   definition(t2) {
                     t2.field('cursor', {
                       type: cursorType ?? nonNull('String'),
-                      description: 'https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor',
+                      description: 'https://relay.dev/graphql/connections.htm#sec-Cursor',
                     })
                     t2.field('node', {
                       type: targetType,
-                      description: 'https://facebook.github.io/relay/graphql/connections.htm#sec-Node',
+                      description: 'https://relay.dev/graphql/connections.htm#sec-Node',
                     })
                     if (pluginExtendEdge) {
                       eachObj(pluginExtendEdge, (val, key) => {
@@ -558,7 +558,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
                 objectType({
                   name: 'PageInfo',
                   description:
-                    'PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo',
+                    'PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo',
                   definition(t2) {
                     t2.nonNull.field('hasNextPage', {
                       type: 'Boolean',

--- a/tests/integrations/kitchenSink/__schema.graphql
+++ b/tests/integrations/kitchenSink/__schema.graphql
@@ -23,7 +23,7 @@ type OfI2 implements I {
 }
 
 """
-PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
 """
 type PageInfo {
   """
@@ -54,12 +54,12 @@ type Post {
 
 type PostConnection {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   """
   edges: [PostEdge]
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   """
   pageInfo: PageInfo!
   totalCount: Int!
@@ -67,13 +67,13 @@ type PostConnection {
 
 type PostEdge {
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor
+  https://relay.dev/graphql/connections.htm#sec-Cursor
   """
   cursor: String!
   delta(format: String): String
 
   """
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Node
+  https://relay.dev/graphql/connections.htm#sec-Node
   """
   node: Post
 }

--- a/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
+++ b/tests/plugins/__snapshots__/connectionPlugin.spec.ts.snap
@@ -183,12 +183,12 @@ Object {
 exports[`basic behavior should adhere to the Relay spec 1`] = `
 "type UserConnection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [UserEdge]
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }"
@@ -196,17 +196,17 @@ exports[`basic behavior should adhere to the Relay spec 1`] = `
 
 exports[`basic behavior should adhere to the Relay spec 2`] = `
 "type UserEdge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: String!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User
 }"
 `;
 
 exports[`basic behavior should adhere to the Relay spec 3`] = `
 "\\"\\"\\"
-PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
 \\"\\"\\"
 type PageInfo {
   \\"\\"\\"
@@ -233,7 +233,7 @@ type PageInfo {
 
 exports[`field level configuration #515 - custom non-string cursor type 1`] = `
 "\\"\\"\\"
-PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
 \\"\\"\\"
 type PageInfo {
   \\"\\"\\"
@@ -301,43 +301,43 @@ type Query {
 
 type QueryFieldLevel2_Connection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [QueryFieldLevel2_Edge!]!
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }
 
 type QueryFieldLevel2_Edge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: UUID4!
   delta: Int!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User!
 }
 
 type QueryFieldLevel_Connection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [QueryFieldLevel_Edge!]!
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }
 
 type QueryFieldLevel_Edge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: UUID!
   delta: Int!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User!
 }
 
@@ -352,29 +352,29 @@ type User {
 
 type UserConnection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [UserEdge!]!
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }
 
 type UserEdge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: UUID!
   delta: Int!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User!
 }"
 `;
 
 exports[`field level configuration #670 should explicitly state nullability for connectionPlugin args & fields 1`] = `
 "\\"\\"\\"
-PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
 \\"\\"\\"
 type PageInfo {
   \\"\\"\\"
@@ -421,21 +421,21 @@ type User {
 
 type UserConnection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [UserEdge!]!
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }
 
 type UserEdge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: String!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User!
 }"
 `;
@@ -447,12 +447,12 @@ exports[`field level configuration can configure edge names per-instance 1`] = `
 exports[`field level configuration can configure the connection per-instance 1`] = `
 "type QueryUsers_Connection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [UserEdge]
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
   totalCount: Int
@@ -462,12 +462,12 @@ exports[`field level configuration can configure the connection per-instance 1`]
 exports[`field level configuration can configure the edge per-instance 1`] = `
 "type QueryUsers_Connection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [QueryUsers_Edge]
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }"
@@ -475,10 +475,10 @@ exports[`field level configuration can configure the edge per-instance 1`] = `
 
 exports[`field level configuration can configure the edge per-instance 2`] = `
 "type QueryUsers_Edge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: String!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User
   role: String
 }"
@@ -489,27 +489,27 @@ exports[`field level configuration can define a schema with multiple plugins, an
   averageCount: Int
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [AnalyticsUserEdge]
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
   totalCount: Int
 }
 
 type AnalyticsUserEdge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: String!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User
 }
 
 \\"\\"\\"
-PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+PageInfo cursor, as defined in https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
 \\"\\"\\"
 type PageInfo {
   \\"\\"\\"
@@ -569,21 +569,21 @@ type User {
 
 type UserConnection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [UserEdge]
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
 }
 
 type UserEdge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: String!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User
 }"
 `;
@@ -704,12 +704,12 @@ exports[`global plugin configuration allows disabling forward pagination w/ stri
 exports[`global plugin configuration can configure additional fields for the connection globally 1`] = `
 "type UserConnection {
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types
+  https://relay.dev/graphql/connections.htm#sec-Edge-Types
   \\"\\"\\"
   edges: [UserEdge]
 
   \\"\\"\\"
-  https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo
+  https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
   \\"\\"\\"
   pageInfo: PageInfo!
   totalCount: Int
@@ -718,10 +718,10 @@ exports[`global plugin configuration can configure additional fields for the con
 
 exports[`global plugin configuration can configure additional fields for the edge globally 1`] = `
 "type UserEdge {
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Cursor\\"\\"\\"
   cursor: String!
 
-  \\"\\"\\"https://facebook.github.io/relay/graphql/connections.htm#sec-Node\\"\\"\\"
+  \\"\\"\\"https://relay.dev/graphql/connections.htm#sec-Node\\"\\"\\"
   node: User
   createdAt: String
 }"


### PR DESCRIPTION
As I brought up in #1069 we'd prefer not to have the word `facebook` in our publicly available schema. @tgriesser asked if changing the links to `relay.dev` was acceptable and we agreed it was. This PR simply changes any `facebook.github.io` links to their respective `relay.dev` links. `facebook.github.io/relay` already redirects to `relay.dev` so this should essentially be a no op from a documentation perspective.