### PR TITLE
fix: add missing as const on the RequestDirectiveLocation

### DIFF
--- a/src/definitions/directive.ts
+++ b/src/definitions/directive.ts
@@ -27,7 +27,7 @@ export const RequestDirectiveLocation = [
   'FRAGMENT_SPREAD',
   'INLINE_FRAGMENT',
   'VARIABLE_DEFINITION',
-]
+] as const
 
 export const SchemaDirectiveLocation = [
   /** Type System Definitions */


### PR DESCRIPTION
This was generating the wrong type `string[]` which meant typesafety was lost on the `locations` for a `directive(` added in #952 