### PR TITLE
fix: remove hasSDLDirectives internal state

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -997,13 +997,6 @@ export class SchemaBuilder {
     this.checkForInterfaceCircularDependencies()
     this.buildNexusTypes()
 
-    // Call the finalTypeMap values as a side-effect, in order to check for the existence of SDL directives
-    Object.values(this.finalTypeMap).forEach((v) => {
-      if (isObjectType(v) || isInterfaceType(v) || isInputObjectType(v)) {
-        v.getFields()
-      }
-    })
-
     return {
       finalConfig: this.config,
       typeMap: this.finalTypeMap,


### PR DESCRIPTION
We don't know if this is true until the schema is constructed, simpler to have a single path for printing schemas, that way we can make sure we're up-to-date with the latest in graphql-js, instead of having the internal SDL printer diverge

More follow up from #952 