### PR TITLE
feat: add sourceType option to fieldDefinition

### DIFF
--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -119,8 +119,27 @@ export type CommonOutputFieldConfig<TypeName extends string, FieldName extends s
    * @example
    *   sourceType: 'string | number'
    */
-  sourceType?: string
+  sourceType?: string | FieldSourceType | NamedFieldSourceType[]
 } & NexusGenPluginFieldConfig<TypeName, FieldName>
+
+export interface FieldSourceType {
+  /**
+   * String representing the TypeScript type output as the value
+   */
+  type: string
+  /**
+   * If true, marks the field as optional `?:`
+   * @default false
+   */
+  optional?: boolean
+}
+
+export interface NamedFieldSourceType extends FieldSourceType {
+  /**
+   * Property name in the output TypeScript field
+   */
+  name: string
+}
 
 export type CommonInputFieldConfig<TypeName extends string, FieldName extends string> = CommonFieldConfig & {
   /** The default value for the field, if any */

--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -111,6 +111,15 @@ export type CommonOutputFieldConfig<TypeName extends string, FieldName extends s
    *   directives: [addDirective('ExampleDirective', { arg: true })]
    */
   directives?: Directives
+  /**
+   * Defines a typing for the field, overriding the default behavior to default to the scalar,
+   * and omit the field if a resolver exists. Most useful in situations where we have a resolver
+   * but we still want the field defined on the output type.
+   *
+   * @example
+   *   sourceType: 'string | number'
+   */
+  sourceType?: string
 } & NexusGenPluginFieldConfig<TypeName, FieldName>
 
 export type CommonInputFieldConfig<TypeName extends string, FieldName extends string> = CommonFieldConfig & {

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -12,6 +12,10 @@ export function hasNexusExtension(val: any): val is any {
   return Boolean(val)
 }
 
+export function isNexusFieldExtension(val: any): val is NexusFieldExtension {
+  return Boolean(val?._type === 'NexusFieldExtension')
+}
+
 export type NexusGraphQLNamedType = GraphQLNamedType & {
   extensions?: {
     nexus?: {
@@ -24,13 +28,17 @@ export type NexusTypeExtensions = NexusObjectTypeExtension | NexusInterfaceTypeE
 
 /** Container object living on `fieldDefinition.extensions.nexus` */
 export class NexusFieldExtension<TypeName extends string = any, FieldName extends string = any> {
+  readonly _type = 'NexusFieldExtension' as const
   readonly config: Omit<NexusOutputFieldConfig<TypeName, FieldName>, 'resolve'>
   /** Whether the user has provided a custom "resolve" function, or whether we're using GraphQL's defaultResolver */
   readonly hasDefinedResolver: boolean
+  readonly sourceType: string | undefined
+
   constructor(config: NexusOutputFieldConfig<TypeName, FieldName>) {
     const { resolve, ...rest } = config
     this.config = rest
     this.hasDefinedResolver = Boolean(resolve && resolve !== defaultFieldResolver)
+    this.sourceType = rest.sourceType
   }
   /** Called when there are modifications on the interface fields */
   modify(modifications: Partial<NexusOutputFieldConfig<any, any>>) {
@@ -40,6 +48,7 @@ export class NexusFieldExtension<TypeName extends string = any, FieldName extend
 
 /** Container object living on `inputObjectType.extensions.nexus` */
 export class NexusInputObjectTypeExtension<TypeName extends string = any> {
+  readonly _type = 'NexusInputObjectTypeExtension' as const
   readonly config: Omit<NexusInputObjectTypeConfig<TypeName>, 'definition'>
   constructor(config: NexusInputObjectTypeConfig<TypeName>) {
     const { definition, ...rest } = config
@@ -49,6 +58,7 @@ export class NexusInputObjectTypeExtension<TypeName extends string = any> {
 
 /** Container object living on `objectType.extensions.nexus` */
 export class NexusObjectTypeExtension<TypeName extends string = any> {
+  readonly _type = 'NexusObjectTypeExtension' as const
   readonly config: Omit<NexusObjectTypeConfig<TypeName>, 'definition' | 'isTypeOf'>
   constructor(config: NexusObjectTypeConfig<TypeName>) {
     const { definition, ...rest } = config
@@ -58,6 +68,7 @@ export class NexusObjectTypeExtension<TypeName extends string = any> {
 
 /** Container object living on `interfaceType.extensions.nexus` */
 export class NexusInterfaceTypeExtension<TypeName extends string = any> {
+  readonly _type = 'NexusInterfaceTypeExtension' as const
   readonly config: Omit<NexusInterfaceTypeConfig<TypeName>, 'definition' | 'resolveType'>
   constructor(config: NexusInterfaceTypeConfig<TypeName>) {
     const { definition, ...rest } = config

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -5,7 +5,7 @@ import type { NexusOutputFieldConfig } from './definitions/definitionBlocks'
 import type { NexusInputObjectTypeConfig } from './definitions/inputObjectType'
 import type { NexusInterfaceTypeConfig } from './definitions/interfaceType'
 import type { NexusObjectTypeConfig } from './definitions/objectType'
-import type { Directives } from './core'
+import type { Directives, FieldSourceType, NamedFieldSourceType } from './core'
 
 /** @internal */
 export function hasNexusExtension(val: any): val is any {
@@ -32,7 +32,7 @@ export class NexusFieldExtension<TypeName extends string = any, FieldName extend
   readonly config: Omit<NexusOutputFieldConfig<TypeName, FieldName>, 'resolve'>
   /** Whether the user has provided a custom "resolve" function, or whether we're using GraphQL's defaultResolver */
   readonly hasDefinedResolver: boolean
-  readonly sourceType: string | undefined
+  readonly sourceType: string | FieldSourceType | NamedFieldSourceType[] | undefined
 
   constructor(config: NexusOutputFieldConfig<TypeName, FieldName>) {
     const { resolve, ...rest } = config

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -643,7 +643,13 @@ export class TypegenPrinter {
           const obj = (rootTypeMap[type.name] = rootTypeMap[type.name] || {})
           const fieldSourceType = this.fieldSourceType(field, type)
           if (typeof obj !== 'string') {
-            if (fieldSourceType) {
+            if (Array.isArray(fieldSourceType)) {
+              for (const field of fieldSourceType) {
+                obj[field.name] = [field.optional ? '?:' : ':', field.type]
+              }
+            } else if (typeof fieldSourceType === 'object') {
+              obj[field.name] = [fieldSourceType.optional ? '?:' : ':', fieldSourceType.type]
+            } else if (fieldSourceType) {
               obj[field.name] = [':', fieldSourceType]
             } else if (!this.hasResolver(field, type)) {
               obj[field.name] = [

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -28,7 +28,7 @@ import { isNexusPrintedGenTyping, isNexusPrintedGenTypingImport } from './defini
 import type { NexusGraphQLSchema } from './definitions/_types'
 import { TYPEGEN_HEADER } from './lang'
 import type { StringLike } from './plugin'
-import { hasNexusExtension } from './extensions'
+import { hasNexusExtension, isNexusFieldExtension } from './extensions'
 import {
   eachObj,
   getOwnPackage,
@@ -641,8 +641,11 @@ export class TypegenPrinter {
       } else {
         eachObj(type.getFields(), (field) => {
           const obj = (rootTypeMap[type.name] = rootTypeMap[type.name] || {})
-          if (!this.hasResolver(field, type)) {
-            if (typeof obj !== 'string') {
+          const fieldSourceType = this.fieldSourceType(field, type)
+          if (typeof obj !== 'string') {
+            if (fieldSourceType) {
+              obj[field.name] = [':', fieldSourceType]
+            } else if (!this.hasResolver(field, type)) {
               obj[field.name] = [
                 this.argSeparator(field.type as GraphQLInputType, false),
                 this.printOutputType(field.type),
@@ -661,6 +664,17 @@ export class TypegenPrinter {
       return typeof rootTyping === 'string' ? rootTyping : rootTyping.export
     }
     return (this.typegenInfo.sourceTypeMap as any)[typeName]
+  }
+
+  private fieldSourceType(
+    field: GraphQLField<any, any>,
+    // Used in test mocking
+    _type: GraphQLObjectType
+  ) {
+    if (field.extensions && isNexusFieldExtension(field.extensions.nexus)) {
+      return field.extensions.nexus.sourceType
+    }
+    return undefined
   }
 
   private hasResolver(

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -1,4 +1,3 @@
-import { defaultTypeResolver } from 'graphql'
 import {
   arg,
   booleanArg,

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -136,6 +136,13 @@ export const i2 = objectType({
         extensionAdditionFromModifyMethod: true,
       },
     })
+    t.string('composite', {
+      resolve: (source) => `${source.fieldA} ${source.fieldB}`,
+      sourceType: [
+        { name: 'fieldA', type: 'string' },
+        { name: 'fieldB', type: 'string' },
+      ],
+    })
   },
 })
 
@@ -194,8 +201,12 @@ export const Post = objectType({
 export const User = objectType({
   name: 'User',
   definition(t) {
-    t.string('firstName')
-    t.string('lastName')
+    t.string('firstName', {
+      sourceType: 'string',
+    })
+    t.string('lastName', {
+      sourceType: 'string',
+    })
     t.connectionField('posts', {
       type: Post,
       nodes() {
@@ -220,8 +231,11 @@ export const User = objectType({
         },
       },
     })
+    t.string('telephone', {
+      sourceType: { type: 'string', optional: true },
+      resolve: (source) => (source.telephone ? `+1 ${source.telephone}` : null),
+    })
   },
-  sourceType: `{ firstName: string, lastName: string }`,
 })
 
 export const Query = extendType({

--- a/tests/integrations/kitchenSink/__app.ts
+++ b/tests/integrations/kitchenSink/__app.ts
@@ -1,3 +1,4 @@
+import { defaultTypeResolver } from 'graphql'
 import {
   arg,
   booleanArg,
@@ -25,6 +26,19 @@ import {
 } from '../../../src'
 import { mockStream } from '../../__helpers'
 import './__typegen'
+
+export const Node = interfaceType({
+  name: 'Node',
+  definition(t) {
+    t.nonNull.id('id', {
+      resolve: (source, args, ctx, info) => `${info.parentType.name}:${source.id}`,
+      sourceType: 'number',
+    })
+  },
+  resolveType(obj: any) {
+    return obj.__typename
+  },
+})
 
 export const typeDirective = directive({
   name: 'TestTypeDirective',
@@ -116,6 +130,7 @@ export const i2 = objectType({
     extensionAdditionFromTypeConfig: true,
   },
   definition(t) {
+    t.implements(Node)
     t.implements('I')
     t.modify('hello', {
       extensions: {

--- a/tests/integrations/kitchenSink/__schema.graphql
+++ b/tests/integrations/kitchenSink/__schema.graphql
@@ -39,12 +39,17 @@ No-Op scalar for testing purposes only
 """
 scalar MyCustomScalar @TestAllDirective
 
+interface Node {
+  id: ID!
+}
+
 type OfI implements I @TestTypeDirective {
   hello: String @TestFieldDirective(bool: true)
 }
 
-type OfI2 implements I {
+type OfI2 implements I & Node {
   hello: String @TestFieldDirective(bool: true)
+  id: ID!
 }
 
 """

--- a/tests/integrations/kitchenSink/__schema.graphql
+++ b/tests/integrations/kitchenSink/__schema.graphql
@@ -48,6 +48,7 @@ type OfI implements I @TestTypeDirective {
 }
 
 type OfI2 implements I & Node {
+  composite: String
   hello: String @TestFieldDirective(bool: true)
   id: ID!
 }
@@ -161,6 +162,7 @@ type User {
     """
     last: Int
   ): PostConnection
+  telephone: String
 }
 
 enum UserStatus {

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -90,6 +90,7 @@ export interface NexusGenObjects {
   OfI2: {
     // root type
     hello?: string | null // String
+    id: number
   }
   PageInfo: {
     // root type
@@ -122,6 +123,7 @@ export interface NexusGenObjects {
 
 export interface NexusGenInterfaces {
   I: NexusGenRootTypes['OfI'] | NexusGenRootTypes['OfI2']
+  Node: NexusGenRootTypes['OfI2']
 }
 
 export interface NexusGenUnions {}
@@ -142,6 +144,7 @@ export interface NexusGenFieldTypes {
   OfI2: {
     // field return type
     hello: string | null // String
+    id: string // ID!
   }
   PageInfo: {
     // field return type
@@ -197,6 +200,10 @@ export interface NexusGenFieldTypes {
     // field return type
     hello: string | null // String
   }
+  Node: {
+    // field return type
+    id: string // ID!
+  }
 }
 
 export interface NexusGenFieldTypeNames {
@@ -211,6 +218,7 @@ export interface NexusGenFieldTypeNames {
   OfI2: {
     // field return type name
     hello: 'String'
+    id: 'ID'
   }
   PageInfo: {
     // field return type name
@@ -266,6 +274,10 @@ export interface NexusGenFieldTypeNames {
     // field return type name
     hello: 'String'
   }
+  Node: {
+    // field return type name
+    id: 'ID'
+  }
 }
 
 export interface NexusGenArgTypes {
@@ -306,11 +318,12 @@ export interface NexusGenArgTypes {
 
 export interface NexusGenAbstractTypeMembers {
   I: 'OfI' | 'OfI2'
+  Node: 'OfI2'
 }
 
 export interface NexusGenTypeInterfaces {
   OfI: 'I'
-  OfI2: 'I'
+  OfI2: 'I' | 'Node'
 }
 
 export type NexusGenObjectNames = keyof NexusGenObjects
@@ -348,7 +361,7 @@ export interface NexusGenDirectiveArgs {
 
 export type NexusGenObjectsUsingAbstractStrategyIsTypeOf = never
 
-export type NexusGenAbstractsUsingStrategyResolveType = 'I'
+export type NexusGenAbstractsUsingStrategyResolveType = 'I' | 'Node'
 
 export type NexusGenFeaturesConfig = {
   abstractTypeStrategies: {

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -89,6 +89,8 @@ export interface NexusGenObjects {
   }
   OfI2: {
     // root type
+    fieldA: string
+    fieldB: string
     hello?: string | null // String
     id: number
   }
@@ -118,7 +120,12 @@ export interface NexusGenObjects {
   }
   Query: {}
   Subscription: {}
-  User: { firstName: string; lastName: string }
+  User: {
+    // root type
+    firstName: string
+    lastName: string
+    telephone?: string
+  }
 }
 
 export interface NexusGenInterfaces {
@@ -143,6 +150,7 @@ export interface NexusGenFieldTypes {
   }
   OfI2: {
     // field return type
+    composite: string | null // String
     hello: string | null // String
     id: string // ID!
   }
@@ -195,6 +203,7 @@ export interface NexusGenFieldTypes {
     firstName: string | null // String
     lastName: string | null // String
     posts: NexusGenRootTypes['PostConnection'] | null // PostConnection
+    telephone: string | null // String
   }
   I: {
     // field return type
@@ -217,6 +226,7 @@ export interface NexusGenFieldTypeNames {
   }
   OfI2: {
     // field return type name
+    composite: 'String'
     hello: 'String'
     id: 'ID'
   }
@@ -269,6 +279,7 @@ export interface NexusGenFieldTypeNames {
     firstName: 'String'
     lastName: 'String'
     posts: 'PostConnection'
+    telephone: 'String'
   }
   I: {
     // field return type name

--- a/tests/interfaceType.spec.ts
+++ b/tests/interfaceType.spec.ts
@@ -292,6 +292,7 @@ it('extensions are inherited and deeply merged by field modifications', () => {
         "foo2": true,
       },
       "nexus": NexusFieldExtension {
+        "_type": "NexusFieldExtension",
         "config": Object {
           "configFor": "outputField",
           "extensions": Object {
@@ -305,6 +306,7 @@ it('extensions are inherited and deeply merged by field modifications', () => {
           "wrapping": undefined,
         },
         "hasDefinedResolver": false,
+        "sourceType": undefined,
       },
     }
   `)


### PR DESCRIPTION
Fixes: #1006, #1003

For situations where we want to ensure that a type exists for a field, even when the field is derived via a `resolver`, this PR adds a `sourceType`. This fixes a longstanding complaint/source of confusion for Nexus about fields that have a resolver, where we still expect the field to exist in the `source`.

Old:
```ts
t.nonNull.id('id', {
  // previously this would be undefined, unless you had a custom `sourceType` on the type-level which defined `id`
  resolve: (source, args, ctx, info) => `${info.parentType.name}:${source.id}` 
})
```

New:

```ts
t.nonNull.id('id', {
  resolve: (source, args, ctx, info) => `${info.parentType.name}:${source.id}`,
  sourceType: 'number' // ensures that `source.id` exists as a `number` field on the generated backing source type
})
```

The API also accepts an object syntax, to specify that a field is optional:

```ts
t.string('name', {
  resolve: (source, args, ctx, info) => source.name ?? 'N/A',
  sourceType: {type: 'string', optional: true} // adds "name" as an optional field
})
```

Also adds an API to define fields that should be added, so we can use the GraphQL object definition as the full source of truth for the generated type, e.g.:

```ts
t.string('name', {
  resolve: (source) => {
    return `${source.firstName} ${source.lastName}`
  },
  sourceType: [
   {name: 'firstName', type: 'string'}, 
   {name: 'lastName', type: 'string'}
  ]
})
```
 