### PR TITLE
fix: typo in Getting Started

### DIFF
--- a/docs/content/010-getting-started/04-why-nexus.mdx
+++ b/docs/content/010-getting-started/04-why-nexus.mdx
@@ -193,7 +193,7 @@ type Post implements Node {
 
 The above example shows a `Node` interface and a `Post` interface implementing it.
 
-The schema definition languange requires that the `Post` type repeats all the fields from the `Node` interface, as a schema becomes bigger and more interfaces and types are added this quickly becomes tedious.
+The schema definition language requires that the `Post` type repeats all the fields from the `Node` interface, as a schema becomes bigger and more interfaces and types are added this quickly becomes tedious.
 
 With Nexus the repetitive work is kept to a bare minimum:
 


### PR DESCRIPTION
Fixed a small typo in the `Why Nexus?` section of the getting started docs