### PR TITLE
fix: Typos in Why Nexus docs

### DIFF
--- a/docs/content/010-getting-started/04-why-nexus.mdx
+++ b/docs/content/010-getting-started/04-why-nexus.mdx
@@ -193,7 +193,7 @@ type Post implements Node {
 
 The above example shows a `Node` interface and a `Post` interface implementing it.
 
-The schema definition languange requires that the `Post` type repeats all the fields from the `Node` interface, as a schema becomes bigger and more interfaces and types are added this quickly becomes tedious.
+The schema definition language requires that the `Post` type repeats all the fields from the `Node` interface, as a schema becomes bigger and more interfaces and types are added this quickly becomes tedious.
 
 With Nexus the repetitive work is kept to a bare minimum:
 
@@ -225,6 +225,6 @@ Thanks to Nexus' rich [plugin system](/api/plugins) it is possible to build more
 
 ## No Need for Extra Tooling
 
-When writing a schema-first GraphQL API, it's often necessary to install and configure several editor extentions and other extra tooling. This is because the Schema Definition Language needs to be properly understood by out editors to be useful.
+When writing a schema-first GraphQL API, it's often necessary to install and configure several editor extentions and other extra tooling. This is because the Schema Definition Language needs to be properly understood by our editors to be useful.
 
 Nexus offers the benefit of providing a great developer experience without the need for any extensions or extra tooling. It also doesn't require developers to learn the Schema Definition Language to be productive. This combination means that JavaScript/TypeScript developers can be added to a project and be successful faster.


### PR DESCRIPTION
Fixed 2 typos in the Getting started section of the docs