### PR TITLE
feat: better esm support, remove top-level node imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ examples/*/dist
 website/static/playground-dist
 yarn-error.log
 coverage/*
-.out
+tests/esm/out/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/*/dist
 website/static/playground-dist
 yarn-error.log
 coverage/*
+.out

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/prettier": "^1.18.3",
     "@typescript-eslint/eslint-plugin": "2.7.0",
     "dripip": "^0.10.0",
+    "esbuild": "^0.14.48",
     "eslint": "^6.6.0",
     "get-port": "^5.1.1",
     "graphql": "^16.3.0",

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,0 +1,8 @@
+export function nodeImports() {
+  const fs = require('fs') as typeof import('fs')
+  const path = require('path') as typeof import('path')
+  return {
+    fs,
+    path,
+  }
+}

--- a/src/typegenFormatPrettier.ts
+++ b/src/typegenFormatPrettier.ts
@@ -1,5 +1,5 @@
-import * as path from 'path'
 import type * as Prettier from 'prettier'
+import { nodeImports } from './node'
 
 export type TypegenFormatFn = (content: string, type: 'types' | 'schema') => string | Promise<string>
 
@@ -21,6 +21,8 @@ export function typegenFormatPrettier(prettierConfig: string | object): TypegenF
     }
 
     let prettierConfigResolved: Prettier.Options
+
+    const path = nodeImports().path
 
     if (typeof prettierConfig === 'string') {
       /* istanbul ignore if */

--- a/src/typegenUtils.ts
+++ b/src/typegenUtils.ts
@@ -68,6 +68,8 @@ export function resolveTypegenConfig(config: BuilderConfigInput): TypegenMetadat
 
 function defaultShouldGenerateArtifacts() {
   return Boolean(
-    typeof process === 'object' && (!process.env.NODE_ENV || process.env.NODE_ENV !== 'production')
+    typeof process === 'object' &&
+      typeof process.cwd === 'function' &&
+      (!process.env.NODE_ENV || process.env.NODE_ENV !== 'production')
   )
 }

--- a/src/typegenUtils.ts
+++ b/src/typegenUtils.ts
@@ -1,65 +1,73 @@
-import * as path from 'path'
 import type { BuilderConfigInput } from './builder'
 import type { ConfiguredTypegen } from './core'
+import { nodeImports } from './node'
 import type { TypegenMetadataConfig } from './typegenMetadata'
 import { assertAbsolutePath, getOwnPackage, isProductionStage } from './utils'
 
 /** Normalizes the builder config into the config we need for typegen */
 export function resolveTypegenConfig(config: BuilderConfigInput): TypegenMetadataConfig {
-  const {
-    outputs,
-    shouldGenerateArtifacts = Boolean(!process.env.NODE_ENV || process.env.NODE_ENV !== 'production'),
-    ...rest
-  } = config
+  const { outputs, shouldGenerateArtifacts = defaultShouldGenerateArtifacts(), ...rest } = config
 
-  const defaultSDLFilePath = path.join(process.cwd(), 'schema.graphql')
+  function getOutputPaths() {
+    const defaultSDLFilePath = nodeImports().path.join(process.cwd(), 'schema.graphql')
 
-  let typegenFilePath: ConfiguredTypegen | null = null
-  let sdlFilePath: string | null = null
+    let typegenFilePath: ConfiguredTypegen | null = null
+    let sdlFilePath: string | null = null
 
-  if (outputs === undefined) {
-    if (isProductionStage()) {
-      sdlFilePath = defaultSDLFilePath
-    }
-  } else if (outputs === true) {
-    sdlFilePath = defaultSDLFilePath
-  } else if (typeof outputs === 'object') {
-    if (outputs.schema === true) {
-      sdlFilePath = defaultSDLFilePath
-    } else if (typeof outputs.schema === 'string') {
-      sdlFilePath = assertAbsolutePath(outputs.schema, 'outputs.schema')
-    } else if (outputs.schema === undefined && isProductionStage()) {
-    }
-    // handle typegen configuration
-    if (typeof outputs.typegen === 'string') {
-      typegenFilePath = {
-        outputPath: assertAbsolutePath(outputs.typegen, 'outputs.typegen'),
+    if (outputs === undefined) {
+      if (isProductionStage()) {
+        sdlFilePath = defaultSDLFilePath
       }
-    } else if (typeof outputs.typegen === 'object') {
-      typegenFilePath = {
-        ...outputs.typegen,
-        outputPath: assertAbsolutePath(outputs.typegen.outputPath, 'outputs.typegen.outputPath'),
-      } as ConfiguredTypegen
-      if (outputs.typegen.globalsPath) {
-        typegenFilePath.globalsPath = assertAbsolutePath(
-          outputs.typegen.globalsPath,
-          'outputs.typegen.globalsPath'
-        )
+    } else if (outputs === true) {
+      sdlFilePath = defaultSDLFilePath
+    } else if (typeof outputs === 'object') {
+      if (outputs.schema === true) {
+        sdlFilePath = defaultSDLFilePath
+      } else if (typeof outputs.schema === 'string') {
+        sdlFilePath = assertAbsolutePath(outputs.schema, 'outputs.schema')
+      } else if (outputs.schema === undefined && isProductionStage()) {
       }
+      // handle typegen configuration
+      if (typeof outputs.typegen === 'string') {
+        typegenFilePath = {
+          outputPath: assertAbsolutePath(outputs.typegen, 'outputs.typegen'),
+        }
+      } else if (typeof outputs.typegen === 'object') {
+        typegenFilePath = {
+          ...outputs.typegen,
+          outputPath: assertAbsolutePath(outputs.typegen.outputPath, 'outputs.typegen.outputPath'),
+        } as ConfiguredTypegen
+        if (outputs.typegen.globalsPath) {
+          typegenFilePath.globalsPath = assertAbsolutePath(
+            outputs.typegen.globalsPath,
+            'outputs.typegen.globalsPath'
+          )
+        }
+      }
+    } else if (outputs !== false) {
+      console.warn(
+        `You should specify a configuration value for outputs in Nexus' makeSchema. ` +
+          `Provide one to remove this warning.`
+      )
     }
-  } else if (outputs !== false) {
-    console.warn(
-      `You should specify a configuration value for outputs in Nexus' makeSchema. ` +
-        `Provide one to remove this warning.`
-    )
+    return {
+      typegenFilePath,
+      sdlFilePath,
+    }
   }
 
   return {
     ...rest,
     nexusSchemaImportId: getOwnPackage().name,
     outputs: {
-      typegen: shouldGenerateArtifacts ? typegenFilePath : null,
-      schema: shouldGenerateArtifacts ? sdlFilePath : null,
+      typegen: shouldGenerateArtifacts ? getOutputPaths().typegenFilePath : null,
+      schema: shouldGenerateArtifacts ? getOutputPaths().sdlFilePath : null,
     },
   }
+}
+
+function defaultShouldGenerateArtifacts() {
+  return Boolean(
+    typeof process === 'object' && (!process.env.NODE_ENV || process.env.NODE_ENV !== 'production')
+  )
 }

--- a/tests/esm/esm-entry.js
+++ b/tests/esm/esm-entry.js
@@ -1,0 +1,16 @@
+import { GraphQLSchema } from 'graphql'
+import { makeSchema, queryType } from '../../dist'
+
+const schema = makeSchema({
+  types: [
+    queryType({
+      definition(t) {
+        t.boolean('ok')
+      },
+    }),
+  ],
+})
+
+if (!(schema instanceof GraphQLSchema)) {
+  throw new Error('Not a schema')
+}

--- a/tests/esm/standalone.spec.ts
+++ b/tests/esm/standalone.spec.ts
@@ -9,14 +9,13 @@ describe('standalone esm', () => {
       bundle: true,
       format: 'esm',
       target: 'esnext',
-      minify: true,
+      // minify: true,
       mainFields: ['module', 'main'],
       external: ['path', 'fs', 'prettier'],
       entryPoints: [path.join(__dirname, 'esm-entry.js')],
       outdir: path.join(__dirname, 'out'),
       outExtension: { '.js': '.mjs' },
       metafile: true,
-      // write: false,
     })
 
     const context = vm.createContext()

--- a/tests/esm/standalone.spec.ts
+++ b/tests/esm/standalone.spec.ts
@@ -5,20 +5,24 @@ import fs from 'fs'
 
 describe('standalone esm', () => {
   it('should build the esbuild', async () => {
-    await esbuild.build({
+    const out = await esbuild.build({
       bundle: true,
       format: 'esm',
       target: 'esnext',
-      external: ['path', 'fs', 'util'],
+      minify: true,
+      mainFields: ['module', 'main'],
+      external: ['path', 'fs', 'prettier'],
       entryPoints: [path.join(__dirname, 'esm-entry.js')],
-      outdir: path.join(__dirname, '.out'),
+      outdir: path.join(__dirname, 'out'),
       outExtension: { '.js': '.mjs' },
+      metafile: true,
       // write: false,
     })
 
     const context = vm.createContext()
     // @ts-ignore
-    const outPath = path.join(__dirname, '.out', 'esm-entry.mjs')
+    const outPath = path.join(__dirname, 'out', 'esm-entry.mjs')
+    fs.writeFileSync(path.join(path.dirname(outPath), 'meta.json'), JSON.stringify(out.metafile))
     const script = new vm.Script(fs.readFileSync(outPath, 'utf8'), {
       filename: outPath,
     })

--- a/tests/esm/standalone.spec.ts
+++ b/tests/esm/standalone.spec.ts
@@ -1,0 +1,27 @@
+import esbuild from 'esbuild'
+import path from 'path'
+import vm from 'vm'
+import fs from 'fs'
+
+describe('standalone esm', () => {
+  it('should build the esbuild', async () => {
+    await esbuild.build({
+      bundle: true,
+      format: 'esm',
+      target: 'esnext',
+      external: ['path', 'fs', 'util'],
+      entryPoints: [path.join(__dirname, 'esm-entry.js')],
+      outdir: path.join(__dirname, '.out'),
+      outExtension: { '.js': '.mjs' },
+      // write: false,
+    })
+
+    const context = vm.createContext()
+    // @ts-ignore
+    const outPath = path.join(__dirname, '.out', 'esm-entry.mjs')
+    const script = new vm.Script(fs.readFileSync(outPath, 'utf8'), {
+      filename: outPath,
+    })
+    script.runInNewContext(context)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2520,6 +2520,132 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
 
+esbuild-android-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.48.tgz#7e6394a0e517f738641385aaf553c7e4fb6d1ae3"
+  integrity sha512-3aMjboap/kqwCUpGWIjsk20TtxVoKck8/4Tu19rubh7t5Ra0Yrpg30Mt1QXXlipOazrEceGeWurXKeFJgkPOUg==
+
+esbuild-android-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.48.tgz#6877566be0f82dd5a43030c0007d06ece7f7c02f"
+  integrity sha512-vptI3K0wGALiDq+EvRuZotZrJqkYkN5282iAfcffjI5lmGG9G1ta/CIVauhY42MBXwEgDJkweiDcDMRLzBZC4g==
+
+esbuild-darwin-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.48.tgz#ea3caddb707d88f844b1aa1dea5ff3b0a71ef1fd"
+  integrity sha512-gGQZa4+hab2Va/Zww94YbshLuWteyKGD3+EsVon8EWTWhnHFRm5N9NbALNbwi/7hQ/hM1Zm4FuHg+k6BLsl5UA==
+
+esbuild-darwin-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.48.tgz#4e5eaab54df66cc319b76a2ac0e8af4e6f0d9c2f"
+  integrity sha512-bFjnNEXjhZT+IZ8RvRGNJthLWNHV5JkCtuOFOnjvo5pC0sk2/QVk0Qc06g2PV3J0TcU6kaPC3RN9yy9w2PSLEA==
+
+esbuild-freebsd-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.48.tgz#47b5abc7426eae66861490ffbb380acc67af5b15"
+  integrity sha512-1NOlwRxmOsnPcWOGTB10JKAkYSb2nue0oM1AfHWunW/mv3wERfJmnYlGzL3UAOIUXZqW8GeA2mv+QGwq7DToqA==
+
+esbuild-freebsd-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.48.tgz#e8c54c8637cd44feed967ea12338b0a4da3a7b11"
+  integrity sha512-gXqKdO8wabVcYtluAbikDH2jhXp+Klq5oCD5qbVyUG6tFiGhrC9oczKq3vIrrtwcxDQqK6+HDYK8Zrd4bCA9Gw==
+
+esbuild-linux-32@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.48.tgz#229cf3246de2b7937c3ac13fac622d4d7a1344c5"
+  integrity sha512-ghGyDfS289z/LReZQUuuKq9KlTiTspxL8SITBFQFAFRA/IkIvDpnZnCAKTCjGXAmUqroMQfKJXMxyjJA69c/nQ==
+
+esbuild-linux-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.48.tgz#7c0e7226c02c42aacc5656c36977493dc1e96c4f"
+  integrity sha512-vni3p/gppLMVZLghI7oMqbOZdGmLbbKR23XFARKnszCIBpEMEDxOMNIKPmMItQrmH/iJrL1z8Jt2nynY0bE1ug==
+
+esbuild-linux-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.48.tgz#0af1eda474b5c6cc0cace8235b74d0cb8fcf57a7"
+  integrity sha512-3CFsOlpoxlKPRevEHq8aAntgYGYkE1N9yRYAcPyng/p4Wyx0tPR5SBYsxLKcgPB9mR8chHEhtWYz6EZ+H199Zw==
+
+esbuild-linux-arm@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.48.tgz#de4d1fa6b77cdcd00e2bb43dd0801e4680f0ab52"
+  integrity sha512-+VfSV7Akh1XUiDNXgqgY1cUP1i2vjI+BmlyXRfVz5AfV3jbpde8JTs5Q9sYgaoq5cWfuKfoZB/QkGOI+QcL1Tw==
+
+esbuild-linux-mips64le@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.48.tgz#822c1778495f7868e990d4da47ad7281df28fd15"
+  integrity sha512-cs0uOiRlPp6ymknDnjajCgvDMSsLw5mST2UXh+ZIrXTj2Ifyf2aAP3Iw4DiqgnyYLV2O/v/yWBJx+WfmKEpNLA==
+
+esbuild-linux-ppc64le@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.48.tgz#55de0a9ec4a48fedfe82a63e083164d001709447"
+  integrity sha512-+2F0vJMkuI0Wie/wcSPDCqXvSFEELH7Jubxb7mpWrA/4NpT+/byjxDz0gG6R1WJoeDefcrMfpBx4GFNN1JQorQ==
+
+esbuild-linux-riscv64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.48.tgz#cd2b7381880b2f4b21a5a598fb673492120f18a5"
+  integrity sha512-BmaK/GfEE+5F2/QDrIXteFGKnVHGxlnK9MjdVKMTfvtmudjY3k2t8NtlY4qemKSizc+QwyombGWTBDc76rxePA==
+
+esbuild-linux-s390x@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.48.tgz#4b319eca2a5c64637fc7397ffbd9671719cdb6bf"
+  integrity sha512-tndw/0B9jiCL+KWKo0TSMaUm5UWBLsfCKVdbfMlb3d5LeV9WbijZ8Ordia8SAYv38VSJWOEt6eDCdOx8LqkC4g==
+
+esbuild-netbsd-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.48.tgz#c27cde8b5cb55dcc227943a18ab078fb98d0adbf"
+  integrity sha512-V9hgXfwf/T901Lr1wkOfoevtyNkrxmMcRHyticybBUHookznipMOHoF41Al68QBsqBxnITCEpjjd4yAos7z9Tw==
+
+esbuild-openbsd-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.48.tgz#af5ab2d1cb41f09064bba9465fc8bf1309150df1"
+  integrity sha512-+IHf4JcbnnBl4T52egorXMatil/za0awqzg2Vy6FBgPcBpisDWT2sVz/tNdrK9kAqj+GZG/jZdrOkj7wsrNTKA==
+
+esbuild-sunos-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.48.tgz#db3ae20526055cf6fd5c4582676233814603ac54"
+  integrity sha512-77m8bsr5wOpOWbGi9KSqDphcq6dFeJyun8TA+12JW/GAjyfTwVtOnN8DOt6DSPUfEV+ltVMNqtXUeTeMAxl5KA==
+
+esbuild-windows-32@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.48.tgz#021ffceb0a3f83078262870da88a912293c57475"
+  integrity sha512-EPgRuTPP8vK9maxpTGDe5lSoIBHGKO/AuxDncg5O3NkrPeLNdvvK8oywB0zGaAZXxYWfNNSHskvvDgmfVTguhg==
+
+esbuild-windows-64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.48.tgz#a4d3407b580f9faac51f61eec095fa985fb3fee4"
+  integrity sha512-YmpXjdT1q0b8ictSdGwH3M8VCoqPpK1/UArze3X199w6u8hUx3V8BhAi1WjbsfDYRBanVVtduAhh2sirImtAvA==
+
+esbuild-windows-arm64@0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.48.tgz#762c0562127d8b09bfb70a3c816460742dd82880"
+  integrity sha512-HHaOMCsCXp0rz5BT2crTka6MPWVno121NKApsGs/OIW5QC0ggC69YMGs1aJct9/9FSUF4A1xNE/cLvgB5svR4g==
+
+esbuild@^0.14.48:
+  version "0.14.48"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.48.tgz#da5d8d25cd2d940c45ea0cfecdca727f7aee2b85"
+  integrity sha512-w6N1Yn5MtqK2U1/WZTX9ZqUVb8IOLZkZ5AdHkT6x3cHDMVsYWC7WPdiLmx19w3i4Rwzy5LqsEMtVihG3e4rFzA==
+  optionalDependencies:
+    esbuild-android-64 "0.14.48"
+    esbuild-android-arm64 "0.14.48"
+    esbuild-darwin-64 "0.14.48"
+    esbuild-darwin-arm64 "0.14.48"
+    esbuild-freebsd-64 "0.14.48"
+    esbuild-freebsd-arm64 "0.14.48"
+    esbuild-linux-32 "0.14.48"
+    esbuild-linux-64 "0.14.48"
+    esbuild-linux-arm "0.14.48"
+    esbuild-linux-arm64 "0.14.48"
+    esbuild-linux-mips64le "0.14.48"
+    esbuild-linux-ppc64le "0.14.48"
+    esbuild-linux-riscv64 "0.14.48"
+    esbuild-linux-s390x "0.14.48"
+    esbuild-netbsd-64 "0.14.48"
+    esbuild-openbsd-64 "0.14.48"
+    esbuild-sunos-64 "0.14.48"
+    esbuild-windows-32 "0.14.48"
+    esbuild-windows-64 "0.14.48"
+    esbuild-windows-arm64 "0.14.48"
+
 escape-goat@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"


### PR DESCRIPTION
Closes #1028

- Removes top-level node imports (`fs`, `path`, `util`)
- Adds conditional flow to ensure these aren't required top-level anywhere when `process` doesn't exist
- Adds test that an `esbuild` script will execute in a VM, where node's require is unavailable

This should make it easier to run Nexus in Cloudflare workers - might not won't work with wrangler2 out of the box without `node_compat = true` b/c it's not as configurable, but should work well with miniflare & a custom esbuild similar to what I added in the test case. 

The codegen should be run separately as a node-script during development for the type-checking, will be opening a separate PR with a helper CLI for that, something like `$ nexus codegen`