### PR TITLE
fix: add missing subcribe when rebuildOutput, solve subcription megreSchema problem

### DIFF
--- a/src/definitions/definitionBlocks.ts
+++ b/src/definitions/definitionBlocks.ts
@@ -13,6 +13,7 @@ import type { Directives } from './directive'
 import type { NexusMetaType } from './nexusMeta'
 import type { AllNexusInputTypeDefs, AllNexusOutputTypeDefs, NexusWrapKind } from './wrapping'
 import type { BaseScalars, Maybe } from './_types'
+import type { IsSubscriptionType, SubscriptionTypeConfigBase } from './subscriptionType'
 
 export interface CommonFieldConfig {
   /** The description to annotate the GraphQL SDL */
@@ -353,6 +354,8 @@ export type FieldOutConfig<TypeName extends string, FieldName extends string> =
         resolve: FieldResolver<TypeName, FieldName>
       }
     : NexusOutputFieldConfig<TypeName, FieldName>
+  &
+  IsSubscriptionType<TypeName> extends true ? SubscriptionTypeConfigBase<FieldName> : {}
 
 // prettier-ignore
 export type FieldOutConfigWithName<TypeName extends string, FieldName extends string> =
@@ -361,6 +364,8 @@ export type FieldOutConfigWithName<TypeName extends string, FieldName extends st
         resolve: FieldResolver<TypeName, FieldName>
       }
     : NexusOutputFieldConfigWithName<TypeName, FieldName>
+  &
+  IsSubscriptionType<TypeName> extends true ? SubscriptionTypeConfigBase<FieldName> : {}
 
 export interface OutputDefinitionBuilder {
   typeName: string

--- a/src/rebuildType.ts
+++ b/src/rebuildType.ts
@@ -178,6 +178,7 @@ export function rebuildOutputDefinition(
       description: fieldConfig.description,
       deprecation: fieldConfig.deprecationReason,
       extensions: fieldConfig.extensions,
+      subscribe: fieldConfig.subscribe,
       args: rebuildArgs(typeName, fieldName, fieldConfig.args ?? {}, config),
       resolve: fieldConfig.resolve,
     })


### PR DESCRIPTION
There is a "Subscription field must return Async Iterable. Received: undefined" problem when merge Subcription type.  It can reproduce here: https://stackblitz.com/edit/graphql-xtfnno?file=index.mjs

I found that the mergeSchema's step `rebuildOutputDefinition` doesn't return subscribe, so it the subscribe will replaced by undefined. this commit add subscribe to return.

Hope it helpful.