### PR TITLE
Not to bind core for connectionPlugin

### DIFF
--- a/src/plugins/connectionPlugin.ts
+++ b/src/plugins/connectionPlugin.ts
@@ -408,7 +408,7 @@ export const connectionPlugin = (connectionPluginConfig?: ConnectionPluginConfig
     fieldDefTypes: [
       printedGenTypingImport({
         module: connectionPluginConfig?.nexusSchemaImportId ?? getOwnPackage().name,
-        bindings: ['core', 'connectionPluginCore'],
+        bindings: ['connectionPluginCore'],
       }),
     ],
     // Defines the field added to the definition block:

--- a/src/typegenPrinter.ts
+++ b/src/typegenPrinter.ts
@@ -255,11 +255,8 @@ export class TypegenPrinter {
     const imports: string[] = []
     const importMap: Record<string, Set<string>> = {}
     const outputPath = this.typegenInfo.typegenPath
-    const nexusSchemaImportId = this.typegenInfo.nexusSchemaImportId ?? getOwnPackage().name
 
-    if (!this.printImports[nexusSchemaImportId]) {
-      this.maybeAddCoreImport(forGlobal)
-    }
+    this.maybeAddCoreImport(forGlobal)
 
     if (!forGlobal) {
       if (contextTypeImport) {
@@ -320,6 +317,7 @@ export class TypegenPrinter {
 
     if (shouldAdd) {
       this.printImports[nexusSchemaImportId] = {
+        ...this.printImports[nexusSchemaImportId],
         core: true,
       }
     }

--- a/tests/integrations/kitchenSink/__typegen.ts
+++ b/tests/integrations/kitchenSink/__typegen.ts
@@ -3,7 +3,7 @@
  * Do not make changes to this file directly
  */
 
-import type { core, connectionPluginCore } from '../../../src'
+import type { connectionPluginCore, core } from '../../../src'
 declare global {
   interface NexusGenCustomInputMethods<TypeName extends string> {
     /**


### PR DESCRIPTION
## Problem

In typegen print process, using `connectionPlugin` always imports `core` from `nexus` even though the plugin doesn’t require.

## Fixes

I tried to fix this by removing `core` from `connectionPlugin` `bindings`. However doing so leads to not importing `core` in any circumstances, which is sometimes required when `dynamicInputFields` and/or `dynamicOutputFields` is present. So I dug a bit deeper to find out following.

In current implementation, `maybeAddCoreImport` is called only when `this.printImports[nexusSchemaImportId]` is `undefined`, which basically means that there is no one configuring `import` from `nexus` package. I believe the origin of this behavior comes from [this change](https://github.com/graphql-nexus/nexus/commit/50bf2981e7e2a461aec767375e0722d796ce2788#diff-5bf40ba45fca8d7b2e157d1fa66f2482f98a22d5efeab2cbfd1632b7f6457399R155).

This behavior is the reason why `core` was omitted when fixing `bindings` in `connectionPlugin`, because it tries to configure `import` from `nexus`.

## Speculation about backward compatibility

The current behavior was introduced because of [backward compatibility](https://github.com/graphql-nexus/nexus/commit/50bf2981e7e2a461aec767375e0722d796ce2788#diff-5bf40ba45fca8d7b2e157d1fa66f2482f98a22d5efeab2cbfd1632b7f6457399R154), which I think means not to break any current schema that manually importing `core`. If so, I believe my fix is better for those people because this can lead them to better state with less config.