### PR TITLE
fix: Remove deprecated graphql method assertValidName and replaced with assertName

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,5 @@
 import {
-  assertValidName,
+  assertName,
   ASTKindToNode,
   defaultFieldResolver,
   GraphQLBoolean,
@@ -1228,7 +1228,7 @@ export class SchemaBuilder {
         // See: https://www.typescriptlang.org/docs/handbook/enums.html
         .filter((key) => isNaN(+key))
         .forEach((key) => {
-          assertValidName(key)
+          assertName(key)
 
           values[key] = {
             value: (members as Record<string, string | number | symbol>)[key],

--- a/src/definitions/directive.ts
+++ b/src/definitions/directive.ts
@@ -1,6 +1,6 @@
 import {
   ArgumentNode,
-  assertValidName,
+  assertName,
   astFromValue,
   ASTKindToNode,
   DirectiveNode,
@@ -109,7 +109,7 @@ withNexusSymbol(NexusDirectiveUse, NexusTypes.DirectiveUse)
 export function directive<DirectiveName extends string>(
   config: NexusDirectiveConfig<DirectiveName>
 ): NexusDirectiveDef<DirectiveName> {
-  assertValidName(config.name)
+  assertName(config.name)
 
   config = Object.freeze(config)
 

--- a/src/definitions/enumType.ts
+++ b/src/definitions/enumType.ts
@@ -1,4 +1,4 @@
-import { assertValidName, GraphQLEnumTypeConfig, GraphQLEnumValueConfig } from 'graphql'
+import { assertName, GraphQLEnumTypeConfig, GraphQLEnumValueConfig } from 'graphql'
 import { arg, NexusArgDef, NexusAsArgConfig } from './args'
 import type { Directives } from './directive'
 import { Maybe, NexusTypes, SourceTypingDef, withNexusSymbol } from './_types'
@@ -64,7 +64,7 @@ export interface NexusEnumTypeConfig<TypeName extends string> {
 
 export class NexusEnumTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusEnumTypeConfig<string>) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/extendInputType.ts
+++ b/src/definitions/extendInputType.ts
@@ -1,4 +1,4 @@
-import { assertValidName } from 'graphql'
+import { assertName } from 'graphql'
 import type { GetGen } from '../typegenTypeHelpers'
 import type { InputDefinitionBlock } from './definitionBlocks'
 import { NexusTypes, withNexusSymbol } from './_types'
@@ -10,7 +10,7 @@ export interface NexusExtendInputTypeConfig<TypeName extends string> {
 
 export class NexusExtendInputTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusExtendInputTypeConfig<any> & { name: string }) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/extendType.ts
+++ b/src/definitions/extendType.ts
@@ -1,4 +1,4 @@
-import { assertValidName } from 'graphql'
+import { assertName } from 'graphql'
 import type { AllOutputTypesPossible } from '../typegenTypeHelpers'
 import type { ObjectDefinitionBlock } from './objectType'
 import type { IsSubscriptionType, SubscriptionBuilder } from './subscriptionType'
@@ -34,7 +34,7 @@ export class NexusExtendTypeDef<TypeName extends string> {
     readonly name: TypeName,
     protected config: NexusExtendTypeConfig<TypeName> & { name: TypeName }
   ) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/inputObjectType.ts
+++ b/src/definitions/inputObjectType.ts
@@ -1,4 +1,4 @@
-import { assertValidName, GraphQLInputObjectTypeConfig } from 'graphql'
+import { assertName, GraphQLInputObjectTypeConfig } from 'graphql'
 import { arg, NexusArgDef, NexusAsArgConfig } from './args'
 import type { InputDefinitionBlock } from './definitionBlocks'
 import type { Directives } from './directive'
@@ -35,7 +35,7 @@ export type NexusInputObjectTypeConfig<TypeName extends string> = {
 
 export class NexusInputObjectTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusInputObjectTypeConfig<any>) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/interfaceType.ts
+++ b/src/definitions/interfaceType.ts
@@ -1,4 +1,4 @@
-import { assertValidName, GraphQLInterfaceTypeConfig } from 'graphql'
+import { assertName, GraphQLInterfaceTypeConfig } from 'graphql'
 import type { FieldResolver, GetGen, InterfaceFieldsFor, ModificationType } from '../typegenTypeHelpers'
 import type { ArgsRecord } from './args'
 import { OutputDefinitionBlock, OutputDefinitionBuilder } from './definitionBlocks'
@@ -89,7 +89,7 @@ export class InterfaceDefinitionBlock<TypeName extends string> extends OutputDef
 
 export class NexusInterfaceTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusInterfaceTypeConfig<TypeName>) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/objectType.ts
+++ b/src/definitions/objectType.ts
@@ -1,4 +1,4 @@
-import { assertValidName, GraphQLObjectType } from 'graphql'
+import { assertName, GraphQLObjectType } from 'graphql'
 import type { InterfaceFieldsFor } from '../typegenTypeHelpers'
 import { OutputDefinitionBlock, OutputDefinitionBuilder } from './definitionBlocks'
 import type { Directives } from './directive'
@@ -204,7 +204,7 @@ export type NexusObjectTypeConfig<TypeName extends string> = {
 
 export class NexusObjectTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusObjectTypeConfig<TypeName>) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/scalarType.ts
+++ b/src/definitions/scalarType.ts
@@ -1,4 +1,4 @@
-import { assertValidName, GraphQLNamedType, GraphQLScalarTypeConfig } from 'graphql'
+import { assertName, GraphQLNamedType, GraphQLScalarTypeConfig } from 'graphql'
 import type { AllNexusInputTypeDefs, AllNexusOutputTypeDefs } from '../core'
 import { decorateType } from './decorateType'
 import type { Directives } from './directive'
@@ -39,7 +39,7 @@ export interface NexusScalarTypeConfig<T extends string> extends ScalarBase, Sca
 
 export class NexusScalarTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusScalarTypeConfig<string>) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config

--- a/src/definitions/unionType.ts
+++ b/src/definitions/unionType.ts
@@ -1,4 +1,4 @@
-import { assertValidName, GraphQLUnionTypeConfig } from 'graphql'
+import { assertName, GraphQLUnionTypeConfig } from 'graphql'
 import type { Directives } from '../core'
 import type { GetGen } from '../typegenTypeHelpers'
 import type { NexusObjectTypeDef } from './objectType'
@@ -55,7 +55,7 @@ export type NexusUnionTypeConfig<TypeName extends string> = {
 
 export class NexusUnionTypeDef<TypeName extends string> {
   constructor(readonly name: TypeName, protected config: NexusUnionTypeConfig<TypeName>) {
-    assertValidName(name)
+    assertName(name)
   }
   get value() {
     return this.config


### PR DESCRIPTION
Remove deprecated graphql method assertValidName and replaced with assertName